### PR TITLE
Only trigger Claude review on explicit PR comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,22 +1,21 @@
 name: Claude Code Review
 
+# Review runs only when a maintainer comments "claude review" on a PR.
+# (Pushes/opens no longer auto-trigger — see chore/manual-claude-review-trigger.)
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  issue_comment:
+    types: [created]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Only run on PR comments (not plain issues) that contain the trigger phrase,
+    # and only from users with write access to avoid external drive-by reviews.
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, 'claude review') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
 
     runs-on: ubuntu-latest
     permissions:
@@ -38,7 +37,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## Summary

- Review workflow was triggering on every push (`pull_request: synchronize`), producing noisy reviews during iterative work
- Now triggers only when a repo owner/member/collaborator comments the phrase `claude review` on a PR
- Comments on non-PR issues and comments by external users are ignored

## How to use

On any open PR, comment:

> claude review

The workflow fires, Claude posts its review, done. To re-trigger, just comment again.

## Test plan

- [ ] After merging, push any change to PR #6 (harness) — confirm NO review fires
- [ ] Comment "claude review" on PR #6 — confirm review fires
- [ ] Comment something unrelated on PR #6 — confirm NO review fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)