### PR TITLE
Defuse MIT OP curtain-bars + axios.com /_next/image GIFs + harness fixes

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"caeaeee8-dbad-4438-9460-450bc6b0d559","pid":57988,"acquiredAt":1776311641744}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"caeaeee8-dbad-4438-9460-450bc6b0d559","pid":57988,"acquiredAt":1776311641744}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/
 # Motion harness artifacts
 tests/motion/reports/
 tests/motion/cookies/
+
+# Claude Code local state
+.claude/

--- a/Still/Still/Still Extension/Resources/background.js
+++ b/Still/Still/Still Extension/Resources/background.js
@@ -139,6 +139,25 @@ api.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     return;
   }
 
+  if (msg.type === 'headProbe') {
+    // Cross-origin HEAD probe on behalf of a content script.
+    // Content-script `fetch` is bound by page CORS, so HEAD requests against
+    // CDN-hosted images (e.g. media.newyorker.com/.../undefined animated GIFs
+    // delivered without Access-Control-Allow-Origin) reject with TypeError —
+    // and Path E ends up marking the image static, leaking the animation.
+    // The service worker fetches in the extension's own origin context with
+    // the manifest's host_permissions, so it can read response headers for
+    // any URL we're authorized for.
+    fetch(msg.url, { method: 'HEAD', credentials: 'omit' })
+      .then((res) => sendResponse({
+        ok: res.ok,
+        status: res.status,
+        contentType: res.headers.get('content-type') || '',
+      }))
+      .catch((e) => sendResponse({ ok: false, error: String(e) }));
+    return true; // async response
+  }
+
   if (msg.type === 'getState') {
     storageGet(['enabled', 'allowlist']).then((result) => {
       const host = msg.host || '';

--- a/Still/Still/Still Extension/Resources/background.js
+++ b/Still/Still/Still Extension/Resources/background.js
@@ -148,6 +148,14 @@ api.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     // The service worker fetches in the extension's own origin context with
     // the manifest's host_permissions, so it can read response headers for
     // any URL we're authorized for.
+    //
+    // Defense-in-depth: only allow http(s). A malicious page setting
+    // `<img src="javascript:...">` or `<img src="file://...">` would
+    // otherwise hand us a privileged fetch we have no business making.
+    if (typeof msg.url !== 'string' || !/^https?:\/\//i.test(msg.url)) {
+      sendResponse({ ok: false, error: 'invalid url' });
+      return true;
+    }
     fetch(msg.url, { method: 'HEAD', credentials: 'omit' })
       .then((res) => sendResponse({
         ok: res.ok,

--- a/Still/Still/Still Extension/Resources/content.js
+++ b/Still/Still/Still Extension/Resources/content.js
@@ -273,30 +273,59 @@
   // interstitial returning text/html with status 403 before the page passes
   // verification). Caller should defer the decision in that case.
 
+  function classifyByContentType(rawCt) {
+    const ct = (rawCt || '').toLowerCase();
+    if (ct.includes('image/gif')) return 'animated';
+    if (ct.includes('image/jpeg') || ct.includes('image/svg') ||
+        ct.includes('image/bmp') || ct.includes('image/avif')) return 'static';
+    if (ct.includes('image/webp') || ct.includes('image/png') || ct.includes('image/apng')) return 'frame-data';
+    return 'unknown';
+  }
+
+  function probeViaBackground(url) {
+    // Content-script fetch is bound by page CORS, so cross-origin CDN URLs
+    // without Access-Control-Allow-Origin reject with TypeError. The service
+    // worker runs in the extension's own origin and uses our manifest
+    // host_permissions, so it can read response headers for any URL we're
+    // authorized for. Used as a fallback when the local HEAD throws.
+    // (newyorker.com homepage is the canonical case — animated GIFs are
+    // served from media.newyorker.com via URLs ending in `/undefined`.)
+    try {
+      const p = api.runtime.sendMessage({ type: 'headProbe', url });
+      if (!p || typeof p.then !== 'function') return Promise.resolve('unknown');
+      return p.then((response) => {
+        if (!response || !response.ok) return 'unknown';
+        const cls = classifyByContentType(response.contentType);
+        // 'frame-data' means we'd need byte-level inspection (animated WebP /
+        // APNG marker) — that's also a cross-origin range fetch we can't do
+        // from the content script, and we don't currently round-trip the
+        // bytes through the service worker. Treat as unknown for now.
+        return cls === 'frame-data' ? 'unknown' : cls;
+      }).catch(() => 'unknown');
+    } catch (e) {
+      return Promise.resolve('unknown');
+    }
+  }
+
   function detectAnimationForExtensionless(url) {
     return fetch(url, { method: 'HEAD', credentials: 'omit' })
       .then((res) => {
         if (!res.ok) return 'unknown';
-        const ct = (res.headers.get('content-type') || '').toLowerCase();
-        if (ct.includes('image/gif')) return 'animated';
-        if (ct.includes('image/jpeg') || ct.includes('image/svg') ||
-            ct.includes('image/bmp') || ct.includes('image/avif')) return 'static';
-        // WebP/APNG could be either — need to check the bytes
-        if (ct.includes('image/webp') || ct.includes('image/png') || ct.includes('image/apng')) {
-          return fetch(url, {
-            credentials: 'omit',
-            headers: { 'Range': 'bytes=0-4095' }
+        const cls = classifyByContentType(res.headers.get('content-type'));
+        if (cls !== 'frame-data') return cls;
+        // WebP / APNG / non-animated PNG: need byte-level inspection.
+        return fetch(url, {
+          credentials: 'omit',
+          headers: { 'Range': 'bytes=0-4095' }
+        })
+          .then((res2) => res2.arrayBuffer())
+          .then((buf) => {
+            const bytes = new Uint8Array(buf);
+            return (isAnimatedWebPBuffer(bytes) || isAnimatedPNGBuffer(bytes)) ? 'animated' : 'static';
           })
-            .then((res2) => res2.arrayBuffer())
-            .then((buf) => {
-              const bytes = new Uint8Array(buf);
-              return (isAnimatedWebPBuffer(bytes) || isAnimatedPNGBuffer(bytes)) ? 'animated' : 'static';
-            })
-            .catch(() => 'unknown');
-        }
-        return 'unknown';
+          .catch(() => 'unknown');
       })
-      .catch(() => 'unknown');
+      .catch(() => probeViaBackground(url));
   }
 
   // --- Spacer detection ---

--- a/Still/Still/Still Extension/Resources/content.js
+++ b/Still/Still/Still Extension/Resources/content.js
@@ -141,6 +141,12 @@
           img.style.visibility = '';
         });
       } else {
+        // Note: init() short-circuits via `initialized` after its first run,
+        // so flipping disabled→enabled on the same page won't re-inject
+        // `style`, the host-rules sheet, or re-scan for missed images. The
+        // popup's expected UX is "toggle requires reload to take effect" and
+        // this preserves that. If we ever want hot re-enable, init() and the
+        // host-rules injector would both need to be made idempotent.
         init();
       }
     });
@@ -505,9 +511,14 @@
         // decision until the image actually loads — by then the resource is
         // definitely fetchable, and a fresh HEAD will return real headers.
         const retry = () => detectAnimationForExtensionless(src).then(apply);
-        if (img.complete && img.naturalWidth > 0) {
-          // Image already loaded between HEAD failing and now — retry now.
-          retry();
+        if (img.complete) {
+          // Image is already done loading. Either it succeeded
+          // (naturalWidth > 0 → retry the HEAD now that the resource is
+          // definitely live) or it errored (naturalWidth === 0 → no
+          // future load/error event will fire, so settle as static now;
+          // otherwise the image would stay visibility:hidden forever).
+          if (img.naturalWidth > 0) retry();
+          else apply('static');
         } else {
           img.addEventListener('load', retry, { once: true });
           img.addEventListener('error', () => apply('static'), { once: true });

--- a/Still/Still/Still Extension/Resources/content.js
+++ b/Still/Still/Still Extension/Resources/content.js
@@ -67,6 +67,30 @@
 
   const api = typeof browser !== 'undefined' ? browser : chrome;
 
+  // --- Per-host CSS rule pack ---
+  // host-rules.json is a curated list of `!important` CSS overrides for sites
+  // where our general defenses don't catch all motion (e.g. JS-driven jQuery
+  // animations against elements with predictable class names — see
+  // president.mit.edu's `.curtain-bar`). Rules are pinned with `!important`
+  // so they beat any inline styles the page's animation library writes per
+  // frame — the animation still "runs", but each frame's value is overridden
+  // before paint, so nothing visibly moves. Async-loaded but applied before
+  // the kinds of animations we target typically fire (jQuery animate triggers
+  // on image-load events, hundreds of ms after document_start).
+  if (api.runtime && typeof api.runtime.getURL === 'function') {
+    fetch(api.runtime.getURL('host-rules.json'))
+      .then((r) => r.json())
+      .then((rules) => {
+        const list = rules[location.hostname];
+        if (!list || !list.length) return;
+        const sheet = document.createElement('style');
+        sheet.id = '__still-host-rules';
+        sheet.textContent = list.join('\n');
+        (document.head || document.documentElement).appendChild(sheet);
+      })
+      .catch(() => {});
+  }
+
   // --- Helpers: wrap callback APIs to handle both Promise (Safari) and callback (Chrome) ---
 
   function storageGet(keys) {
@@ -243,17 +267,20 @@
   }
 
   // --- Detect animation for extensionless URLs ---
-  // Two-step: HEAD to get content-type, then partial fetch if needed
+  // Two-step: HEAD to get content-type, then partial fetch if needed.
+  // Returns 'animated', 'static', or 'unknown'. 'unknown' means HEAD failed
+  // or returned a content-type we can't classify (e.g., a Cloudflare
+  // interstitial returning text/html with status 403 before the page passes
+  // verification). Caller should defer the decision in that case.
 
   function detectAnimationForExtensionless(url) {
     return fetch(url, { method: 'HEAD', credentials: 'omit' })
       .then((res) => {
+        if (!res.ok) return 'unknown';
         const ct = (res.headers.get('content-type') || '').toLowerCase();
-        // GIF is always animated
-        if (ct.includes('image/gif')) return true;
-        // Static formats — definitely not animated
+        if (ct.includes('image/gif')) return 'animated';
         if (ct.includes('image/jpeg') || ct.includes('image/svg') ||
-            ct.includes('image/bmp') || ct.includes('image/avif')) return false;
+            ct.includes('image/bmp') || ct.includes('image/avif')) return 'static';
         // WebP/APNG could be either — need to check the bytes
         if (ct.includes('image/webp') || ct.includes('image/png') || ct.includes('image/apng')) {
           return fetch(url, {
@@ -263,12 +290,13 @@
             .then((res2) => res2.arrayBuffer())
             .then((buf) => {
               const bytes = new Uint8Array(buf);
-              return isAnimatedWebPBuffer(bytes) || isAnimatedPNGBuffer(bytes);
-            });
+              return (isAnimatedWebPBuffer(bytes) || isAnimatedPNGBuffer(bytes)) ? 'animated' : 'static';
+            })
+            .catch(() => 'unknown');
         }
-        return false;
+        return 'unknown';
       })
-      .catch(() => false);
+      .catch(() => 'unknown');
   }
 
   // --- Spacer detection ---
@@ -415,12 +443,34 @@
       img.dataset.still = 'probing';
       img.style.visibility = 'hidden';
 
-      detectAnimationForExtensionless(src).then((animated) => {
-        if (animated) {
+      const apply = (result) => {
+        if (result === 'animated') {
           replaceWithPlaceholder(img);
         } else {
+          // 'static' or final 'unknown' — fail open (show image). The retry
+          // path below already handled the recoverable-unknown case.
           img.dataset.still = 'static';
           img.style.visibility = '';
+        }
+      };
+
+      detectAnimationForExtensionless(src).then((result) => {
+        if (result !== 'unknown') {
+          apply(result);
+          return;
+        }
+        // HEAD failed at scan time. Common cause: the page navigated through
+        // Cloudflare's "Just a moment..." interstitial, our scan ran on the
+        // pre-verification document, and the resource was 403'd. Defer the
+        // decision until the image actually loads — by then the resource is
+        // definitely fetchable, and a fresh HEAD will return real headers.
+        const retry = () => detectAnimationForExtensionless(src).then(apply);
+        if (img.complete && img.naturalWidth > 0) {
+          // Image already loaded between HEAD failing and now — retry now.
+          retry();
+        } else {
+          img.addEventListener('load', retry, { once: true });
+          img.addEventListener('error', () => apply('static'), { once: true });
         }
       });
     }

--- a/Still/Still/Still Extension/Resources/content.js
+++ b/Still/Still/Still Extension/Resources/content.js
@@ -83,6 +83,12 @@
       .then((rules) => {
         const list = rules[location.hostname];
         if (!list || !list.length) return;
+        // checkState() is async and may have run before this fetch resolves.
+        // If it concluded the extension is disabled / site is allowlisted,
+        // skip the inject — otherwise the sheet would land in the DOM after
+        // the cleanup pass and stick around forever (e.g. allowlisting
+        // president.mit.edu would still pin curtain bars at left:100%).
+        if (!enabled || siteAllowed) return;
         const sheet = document.createElement('style');
         sheet.id = '__still-host-rules';
         sheet.textContent = list.join('\n');
@@ -125,6 +131,11 @@
 
       if (!enabled || siteAllowed) {
         style.remove();
+        // Also drop the per-host CSS rule pack — otherwise allowlisting a
+        // site that has a host-rules entry (e.g. president.mit.edu) would
+        // leave the curtain bars permanently pinned at left:100%, since the
+        // !important rule keeps overriding the page's inline-style writes.
+        document.getElementById('__still-host-rules')?.remove();
         document.querySelectorAll('img[data-still="replacing"]').forEach((img) => {
           img.dataset.still = '';
           img.style.visibility = '';

--- a/Still/Still/Still Extension/Resources/host-rules.json
+++ b/Still/Still/Still Extension/Resources/host-rules.json
@@ -1,0 +1,5 @@
+{
+  "president.mit.edu": [
+    ".curtain-bar { left: 100% !important; }"
+  ]
+}

--- a/Still/Still/Still Extension/Resources/main-world-patch.js
+++ b/Still/Still/Still Extension/Resources/main-world-patch.js
@@ -61,4 +61,40 @@
     }
     return origSetAttributeNS.apply(this, arguments);
   };
+
+  // --- jQuery animation disable ---
+  // jQuery's .animate / .fadeIn / .slideUp etc use requestAnimationFrame and
+  // write inline style per frame — invisible to our CSS transition override
+  // and the WAAPI cancellation pass (they're not Animation objects). Pages
+  // like president.mit.edu's hero "curtain-bars" sweep 6 colored bars across
+  // the viewport via `$(el).delay(N).animate({left:'98%'}, 500–700)` — a
+  // migraine-grade flourish that the rest of our pipeline misses.
+  //
+  // jQuery ships a global kill-switch: `jQuery.fx.off = true` completes every
+  // animation synchronously on the next tick, skipping straight to the end
+  // state. We intercept `window.jQuery` and `window.$` via defineProperty so
+  // the flag is flipped the instant the page assigns either one. Zepto uses
+  // the same `fx.off` convention so this patch covers it too.
+  function patchAnimatedLibrary(v) {
+    // jQuery's `.fx` is `Tween.prototype.init`, which is a function (with
+    // .step, .speeds, .tick, .off attached). Zepto's `.fx` is also a function
+    // (constructor). Check for function OR object — excluding only null/prim.
+    if (v && v.fx && (typeof v.fx === 'object' || typeof v.fx === 'function')) {
+      try { v.fx.off = true; } catch (e) { /* frozen / sealed fx */ }
+    }
+    return v;
+  }
+  function defineJQueryGlobal(name) {
+    let slot = window[name];
+    if (slot) patchAnimatedLibrary(slot);
+    try {
+      Object.defineProperty(window, name, {
+        configurable: true,
+        get: function () { return slot; },
+        set: function (val) { slot = patchAnimatedLibrary(val); },
+      });
+    } catch (e) { /* existing non-configurable property; best-effort only */ }
+  }
+  defineJQueryGlobal('jQuery');
+  defineJQueryGlobal('$');
 })();

--- a/Still/Still/Still Extension/Resources/manifest.json
+++ b/Still/Still/Still Extension/Resources/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Still",
-  "version": "1.2",
+  "version": "1.3",
   "description": "Block animated GIFs, WebP, and APNG. Pause autoplay video. Cancel CSS animations.",
   "permissions": [
     "activeTab",

--- a/Still/Still/Still Extension/Resources/manifest.json
+++ b/Still/Still/Still Extension/Resources/manifest.json
@@ -63,7 +63,7 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["icons/frozen.svg"],
+      "resources": ["icons/frozen.svg", "host-rules.json"],
       "matches": ["<all_urls>"]
     }
   ]

--- a/Still/Still/Still.xcodeproj/project.pbxproj
+++ b/Still/Still/Still.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		FC81B1582F734DDF00E56099 /* rules in Resources */ = {isa = PBXBuildFile; fileRef = FC81B14F2F734DDF00E56099 /* rules */; };
 		FC81B1592F734DDF00E56099 /* popup.css in Resources */ = {isa = PBXBuildFile; fileRef = FC81B1502F734DDF00E56099 /* popup.css */; };
 		FC81B15A2F734DDF00E56099 /* content.js in Resources */ = {isa = PBXBuildFile; fileRef = FC81B1512F734DDF00E56099 /* content.js */; };
+		1E181FF1AEF142F485365625 /* main-world-patch.js in Resources */ = {isa = PBXBuildFile; fileRef = 465B1C11FB21456A9E0C3F79 /* main-world-patch.js */; };
+		A7E98BF945CC4591A4AE74F2 /* host-rules.json in Resources */ = {isa = PBXBuildFile; fileRef = F4D0E8FA40AD41ED88CA26D4 /* host-rules.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +81,8 @@
 		FC81B14F2F734DDF00E56099 /* rules */ = {isa = PBXFileReference; lastKnownFileType = folder; name = rules; path = Resources/rules; sourceTree = "<group>"; };
 		FC81B1502F734DDF00E56099 /* popup.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; name = popup.css; path = Resources/popup.css; sourceTree = "<group>"; };
 		FC81B1512F734DDF00E56099 /* content.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = content.js; path = Resources/content.js; sourceTree = "<group>"; };
+		465B1C11FB21456A9E0C3F79 /* main-world-patch.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = "main-world-patch.js"; path = "Resources/main-world-patch.js"; sourceTree = "<group>"; };
+		F4D0E8FA40AD41ED88CA26D4 /* host-rules.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = "host-rules.json"; path = "Resources/host-rules.json"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -165,6 +169,8 @@
 				FC81B14F2F734DDF00E56099 /* rules */,
 				FC81B1502F734DDF00E56099 /* popup.css */,
 				FC81B1512F734DDF00E56099 /* content.js */,
+				465B1C11FB21456A9E0C3F79 /* main-world-patch.js */,
+				F4D0E8FA40AD41ED88CA26D4 /* host-rules.json */,
 			);
 			name = Resources;
 			path = "Still Extension";
@@ -279,6 +285,8 @@
 				FC81B15A2F734DDF00E56099 /* content.js in Resources */,
 				FC81B1572F734DDF00E56099 /* manifest.json in Resources */,
 				FC81B1522F734DDF00E56099 /* popup.js in Resources */,
+				1E181FF1AEF142F485365625 /* main-world-patch.js in Resources */,
+				A7E98BF945CC4591A4AE74F2 /* host-rules.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Still/Still/Still.xcodeproj/project.pbxproj
+++ b/Still/Still/Still.xcodeproj/project.pbxproj
@@ -472,7 +472,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 55XHFQJ4X3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Still Extension/Info.plist";
@@ -484,7 +484,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -505,7 +505,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 55XHFQJ4X3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Still Extension/Info.plist";
@@ -517,7 +517,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -540,7 +540,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 55XHFQJ4X3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Still/Info.plist;
@@ -555,7 +555,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -580,7 +580,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 55XHFQJ4X3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Still/Info.plist;
@@ -595,7 +595,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,20 @@
         "@types/node": "^25.6.0",
         "playwright-extra": "^4.3.6",
         "puppeteer-extra-plugin-stealth": "^2.11.2",
+        "sharp": "^0.34.5",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -459,6 +471,544 @@
         "node": ">=18"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
@@ -580,6 +1130,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/esbuild": {
@@ -1094,6 +1654,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shallow-clone": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
@@ -1132,6 +1705,59 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "still",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "still",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.58.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/node": "^25.6.0",
     "playwright-extra": "^4.3.6",
     "puppeteer-extra-plugin-stealth": "^2.11.2",
+    "sharp": "^0.34.5",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2"
   }

--- a/tests/freeze.spec.js
+++ b/tests/freeze.spec.js
@@ -111,6 +111,15 @@ test.afterAll(async () => {
   if (xOriginServer) xOriginServer.close();
 });
 
+// Reset request-counter globals before each test so a counter incremented in
+// one test doesn't bleed into another that touches the same route. (e.g.
+// __cfHeadCount: tests beyond the first that hit /cf-protected-image would
+// otherwise see HEAD #2+ and get 200 instead of 403 — silently breaking the
+// interstitial-race simulation.)
+test.beforeEach(() => {
+  global.__cfHeadCount = 0;
+});
+
 async function injectContentScript(page, opts = {}) {
   // hostRulesURL: when set, the mocked browser.runtime.getURL() will resolve
   // 'host-rules.json' to that URL (the test server's /host-rules.json route).
@@ -120,13 +129,17 @@ async function injectContentScript(page, opts = {}) {
   // will respond to {type:'headProbe'} messages with that content-type, as
   // if the background service worker had successfully fetched the URL with
   // its extension-origin permissions. Tests the cross-origin CORS fallback.
+  // initialState: overrides the default {enabled:true, allowlist:[]} returned
+  // by the mocked storage.local.get. Use to simulate a disabled extension or
+  // an allowlisted site at scan time.
   const hostRulesURL = opts.hostRulesURL || '';
   const headProbeContentType = opts.headProbeContentType || '';
-  await page.addInitScript(({ u, hpct }) => {
+  const initialState = opts.initialState || { enabled: true, allowlist: [] };
+  await page.addInitScript(({ u, hpct, state }) => {
     window.browser = {
       storage: {
         local: {
-          get(keys, cb) { cb({ enabled: true, allowlist: [] }); },
+          get(keys, cb) { cb(state); },
           set() {}
         }
       },
@@ -141,7 +154,7 @@ async function injectContentScript(page, opts = {}) {
         getURL(path) { return u + '/' + path; }
       }
     };
-  }, { u: hostRulesURL, hpct: headProbeContentType });
+  }, { u: hostRulesURL, hpct: headProbeContentType, state: initialState });
 }
 
 const PLACEHOLDER_PREFIX = "data:image/svg+xml,";
@@ -348,6 +361,26 @@ test.describe('Still — block and replace logic', () => {
     expect(sheetText).toContain('.test-host-rule-target');
   });
 
+  test('per-host CSS rule pack — host-rules sheet is removed when the extension is disabled / site is allowlisted', async ({ page }) => {
+    // Regression for the bug where allowlisting a host-rules site (e.g.
+    // president.mit.edu) would leave the curtain bars permanently pinned at
+    // left:100% — checkState() removed the main __still-hide block but not
+    // __still-host-rules, so the page-level !important override stuck around.
+    await injectContentScript(page, {
+      hostRulesURL: baseURL,
+      initialState: { enabled: false, allowlist: [] },
+    });
+    await page.goto(baseURL + '/test-page.html');
+    await page.addScriptTag({ path: CONTENT_SCRIPT });
+
+    // Once checkState() resolves with enabled:false, both the main style
+    // block AND the host-rules sheet should be gone from the DOM.
+    await page.waitForFunction(() => {
+      return !document.getElementById('__still-hide') &&
+             !document.getElementById('__still-host-rules');
+    }, { timeout: 5000 });
+  });
+
   test('per-host CSS rule pack — bundled host-rules.json is well-formed and contains the MIT OP rule', async () => {
     const rulesPath = path.resolve(__dirname, '..', 'web-extension', 'host-rules.json');
     const rules = JSON.parse(fs.readFileSync(rulesPath, 'utf8'));
@@ -402,7 +435,8 @@ test.describe('Still — block and replace logic', () => {
     // came back 403/text-html. After the image then loaded successfully, no
     // re-check fired and the GIF animated unblocked. The fix: treat HEAD
     // failure/unknown as deferred, retry on `load`.
-    global.__cfHeadCount = 0;
+    // (__cfHeadCount reset is in test.beforeEach so other tests touching
+    // /cf-protected-image stay deterministic too.)
     await injectContentScript(page);
     await page.goto(baseURL + '/test-page.html');
 

--- a/tests/freeze.spec.js
+++ b/tests/freeze.spec.js
@@ -24,8 +24,18 @@ function createHandler(corsOrigin) {
       '.js': 'text/javascript'
     };
 
-    if (corsOrigin) {
+    // Skip CORS for the /no-cors-* paths — used by the test that exercises
+    // the background-mediated HEAD probe fallback (newyorker.com pattern).
+    if (corsOrigin && !urlPath.startsWith('/no-cors-')) {
       res.setHeader('Access-Control-Allow-Origin', corsOrigin);
+    }
+
+    if (urlPath === '/no-cors-gif') {
+      const gifPath = path.join(TESTS_DIR, 'fixtures', 'animated.gif');
+      const data = fs.readFileSync(gifPath);
+      res.writeHead(200, { 'Content-Type': 'image/gif' });
+      res.end(data);
+      return;
     }
 
     // Host-rules JSON used by the per-host CSS rule pack test. Rule keys off
@@ -106,8 +116,13 @@ async function injectContentScript(page, opts = {}) {
   // 'host-rules.json' to that URL (the test server's /host-rules.json route).
   // Tests that don't care about host-rules can leave this unset; the loader's
   // fetch will fail silently.
+  // headProbeContentType: when set, the mocked browser.runtime.sendMessage
+  // will respond to {type:'headProbe'} messages with that content-type, as
+  // if the background service worker had successfully fetched the URL with
+  // its extension-origin permissions. Tests the cross-origin CORS fallback.
   const hostRulesURL = opts.hostRulesURL || '';
-  await page.addInitScript((u) => {
+  const headProbeContentType = opts.headProbeContentType || '';
+  await page.addInitScript(({ u, hpct }) => {
     window.browser = {
       storage: {
         local: {
@@ -117,11 +132,16 @@ async function injectContentScript(page, opts = {}) {
       },
       runtime: {
         onMessage: { addListener() {} },
-        sendMessage() { return Promise.resolve(); },
+        sendMessage(msg) {
+          if (msg && msg.type === 'headProbe' && hpct) {
+            return Promise.resolve({ ok: true, status: 200, contentType: hpct });
+          }
+          return Promise.resolve();
+        },
         getURL(path) { return u + '/' + path; }
       }
     };
-  }, hostRulesURL);
+  }, { u: hostRulesURL, hpct: headProbeContentType });
 }
 
 const PLACEHOLDER_PREFIX = "data:image/svg+xml,";
@@ -340,6 +360,39 @@ test.describe('Still — block and replace logic', () => {
     const joined = rules['president.mit.edu'].join('\n');
     expect(joined).toMatch(/\.curtain-bar/);
     expect(joined).toMatch(/!important/);
+  });
+
+  test('falls back to background HEAD probe when content-script fetch is CORS-blocked (newyorker.com pattern)', async ({ page }) => {
+    // Reproduces the New Yorker homepage bug: animated GIFs served from
+    // media.newyorker.com via URLs ending in `/undefined` (a JS template
+    // bug at NYer that ships anyway). The CDN serves Content-Type:
+    // image/gif but no Access-Control-Allow-Origin, so the content
+    // script's HEAD fetch from www.newyorker.com → media.newyorker.com
+    // rejects with TypeError. Path E used to give up there and mark the
+    // image static, leaking the animation. The fix routes the HEAD probe
+    // through the background service worker, which fetches in extension
+    // origin context and isn't bound by page CORS.
+    await injectContentScript(page, { headProbeContentType: 'image/gif' });
+    await page.goto(baseURL + '/test-page.html');
+
+    await page.evaluate((xo) => {
+      const img = document.createElement('img');
+      img.id = 'img-cors-blocked';
+      // Cross-origin (different port) + extensionless URL + no CORS header
+      // on the response. fetch HEAD will reject; load will succeed.
+      img.src = xo + '/no-cors-gif';
+      document.body.appendChild(img);
+    }, xOriginURL);
+
+    await page.addScriptTag({ path: CONTENT_SCRIPT });
+
+    await page.waitForFunction(() => {
+      const img = document.getElementById('img-cors-blocked');
+      return img && img.dataset.still === 'replaced';
+    }, { timeout: 8000 });
+
+    const src = await page.$eval('#img-cors-blocked', el => el.src);
+    expect(src).toMatch(/^data:image\/svg\+xml/);
   });
 
   test('retries detection on image load when initial HEAD fails (Cloudflare-interstitial race)', async ({ page }) => {

--- a/tests/freeze.spec.js
+++ b/tests/freeze.spec.js
@@ -28,6 +28,17 @@ function createHandler(corsOrigin) {
       res.setHeader('Access-Control-Allow-Origin', corsOrigin);
     }
 
+    // Host-rules JSON used by the per-host CSS rule pack test. Rule keys off
+    // the test server's hostname (127.0.0.1) and pins a known property so the
+    // test can verify the override actually beats inline style writes.
+    if (urlPath === '/host-rules.json') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        '127.0.0.1': ['.test-host-rule-target { left: 999px !important; }']
+      }));
+      return;
+    }
+
     if (urlPath === '/cdn-image') {
       const gifPath = path.join(TESTS_DIR, 'fixtures', 'animated.gif');
       const data = fs.readFileSync(gifPath);
@@ -90,8 +101,13 @@ test.afterAll(async () => {
   if (xOriginServer) xOriginServer.close();
 });
 
-async function injectContentScript(page) {
-  await page.addInitScript(() => {
+async function injectContentScript(page, opts = {}) {
+  // hostRulesURL: when set, the mocked browser.runtime.getURL() will resolve
+  // 'host-rules.json' to that URL (the test server's /host-rules.json route).
+  // Tests that don't care about host-rules can leave this unset; the loader's
+  // fetch will fail silently.
+  const hostRulesURL = opts.hostRulesURL || '';
+  await page.addInitScript((u) => {
     window.browser = {
       storage: {
         local: {
@@ -101,10 +117,11 @@ async function injectContentScript(page) {
       },
       runtime: {
         onMessage: { addListener() {} },
-        sendMessage() { return Promise.resolve(); }
+        sendMessage() { return Promise.resolve(); },
+        getURL(path) { return u + '/' + path; }
       }
     };
-  });
+  }, hostRulesURL);
 }
 
 const PLACEHOLDER_PREFIX = "data:image/svg+xml,";
@@ -275,6 +292,54 @@ test.describe('Still — block and replace logic', () => {
 
     const src = await page.$eval('#img-extensionless', el => el.src);
     expect(src).toMatch(/^data:image\/svg\+xml/);
+  });
+
+  test('per-host CSS rule pack — applies matching rules and beats inline style', async ({ page }) => {
+    // Verifies the host-rules.json mechanism: content.js fetches the rule pack
+    // at init, finds rules keyed to location.hostname, and injects them as an
+    // !important stylesheet that overrides inline-style writes (the
+    // jQuery-animate / curtain-bar pattern from president.mit.edu).
+    await injectContentScript(page, { hostRulesURL: baseURL });
+    await page.goto(baseURL + '/test-page.html');
+
+    // Element with the targeted class + an inline style the rule should beat.
+    await page.evaluate(() => {
+      const el = document.createElement('div');
+      el.id = 'host-rule-target';
+      el.className = 'test-host-rule-target';
+      el.style.position = 'absolute';
+      el.style.left = '0px';
+      document.body.appendChild(el);
+    });
+
+    await page.addScriptTag({ path: CONTENT_SCRIPT });
+
+    // The rule pins left: 999px !important; even though inline style says 0px,
+    // computed style should reflect the rule.
+    await page.waitForFunction(() => {
+      const el = document.getElementById('host-rule-target');
+      return el && getComputedStyle(el).left === '999px';
+    }, { timeout: 5000 });
+
+    // And confirm the host-rules style block actually exists in the DOM
+    const sheetText = await page.evaluate(() =>
+      (document.getElementById('__still-host-rules') || {}).textContent
+    );
+    expect(sheetText).toContain('.test-host-rule-target');
+  });
+
+  test('per-host CSS rule pack — bundled host-rules.json is well-formed and contains the MIT OP rule', async () => {
+    const rulesPath = path.resolve(__dirname, '..', 'web-extension', 'host-rules.json');
+    const rules = JSON.parse(fs.readFileSync(rulesPath, 'utf8'));
+    expect(typeof rules).toBe('object');
+    // toHaveProperty treats dots as nested paths — pass key as array for
+    // literal dots in the host name.
+    expect(rules).toHaveProperty(['president.mit.edu']);
+    expect(Array.isArray(rules['president.mit.edu'])).toBe(true);
+    // Must contain the curtain-bar fix that defuses the hero flourish.
+    const joined = rules['president.mit.edu'].join('\n');
+    expect(joined).toMatch(/\.curtain-bar/);
+    expect(joined).toMatch(/!important/);
   });
 
   test('retries detection on image load when initial HEAD fails (Cloudflare-interstitial race)', async ({ page }) => {

--- a/tests/freeze.spec.js
+++ b/tests/freeze.spec.js
@@ -36,6 +36,34 @@ function createHandler(corsOrigin) {
       return;
     }
 
+    // Simulates the Cloudflare-interstitial race seen on axios.com:
+    // the first HEAD request gets 403/text-html (page is mid-verification),
+    // subsequent HEADs and the GET return the real gif. The image GET is
+    // also delayed slightly so the content script has time to install its
+    // retry listener before the load event fires.
+    if (urlPath === '/cf-protected-image') {
+      if (req.method === 'HEAD') {
+        global.__cfHeadCount = (global.__cfHeadCount || 0) + 1;
+        if (global.__cfHeadCount === 1) {
+          res.writeHead(403, { 'Content-Type': 'text/html' });
+          res.end();
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'image/gif', 'Content-Length': '1024' });
+        res.end();
+        return;
+      }
+      // GET — return the real gif after a short delay so the listener gets
+      // attached first.
+      setTimeout(() => {
+        const gifPath = path.join(TESTS_DIR, 'fixtures', 'animated.gif');
+        const data = fs.readFileSync(gifPath);
+        res.writeHead(200, { 'Content-Type': 'image/gif' });
+        res.end(data);
+      }, 300);
+      return;
+    }
+
     try {
       const data = fs.readFileSync(filePath);
       res.writeHead(200, { 'Content-Type': types[ext] || 'application/octet-stream' });
@@ -246,6 +274,35 @@ test.describe('Still — block and replace logic', () => {
     }, { timeout: 5000 });
 
     const src = await page.$eval('#img-extensionless', el => el.src);
+    expect(src).toMatch(/^data:image\/svg\+xml/);
+  });
+
+  test('retries detection on image load when initial HEAD fails (Cloudflare-interstitial race)', async ({ page }) => {
+    // Reproduces the axios.com landing-page bug: extensionless image URL
+    // (Next.js /_next/image proxy) was wrongly marked `static` because the
+    // initial HEAD landed during Cloudflare's "Just a moment..." phase and
+    // came back 403/text-html. After the image then loaded successfully, no
+    // re-check fired and the GIF animated unblocked. The fix: treat HEAD
+    // failure/unknown as deferred, retry on `load`.
+    global.__cfHeadCount = 0;
+    await injectContentScript(page);
+    await page.goto(baseURL + '/test-page.html');
+
+    await page.evaluate((base) => {
+      const img = document.createElement('img');
+      img.id = 'img-cf';
+      img.src = base + '/cf-protected-image';
+      document.body.appendChild(img);
+    }, baseURL);
+
+    await page.addScriptTag({ path: CONTENT_SCRIPT });
+
+    await page.waitForFunction(() => {
+      const img = document.getElementById('img-cf');
+      return img && img.dataset.still === 'replaced';
+    }, { timeout: 8000 });
+
+    const src = await page.$eval('#img-cf', el => el.src);
     expect(src).toMatch(/^data:image\/svg\+xml/);
   });
 

--- a/tests/freeze.spec.js
+++ b/tests/freeze.spec.js
@@ -49,6 +49,14 @@ function createHandler(corsOrigin) {
       return;
     }
 
+    // Always 404 — used to construct an already-errored image whose
+    // load/error events have already fired before content.js scans it.
+    if (urlPath === '/broken-image') {
+      res.writeHead(404, { 'Content-Type': 'text/html' });
+      res.end('not found');
+      return;
+    }
+
     if (urlPath === '/cdn-image') {
       const gifPath = path.join(TESTS_DIR, 'fixtures', 'animated.gif');
       const data = fs.readFileSync(gifPath);
@@ -136,15 +144,25 @@ async function injectContentScript(page, opts = {}) {
   const headProbeContentType = opts.headProbeContentType || '';
   const initialState = opts.initialState || { enabled: true, allowlist: [] };
   await page.addInitScript(({ u, hpct, state }) => {
+    // Mutable state lives on a window-level slot so tests can flip it via
+    // page.evaluate and then trigger a stateChanged message to exercise the
+    // disable / re-enable cleanup paths in checkState().
+    window.__stillTestState = state;
+    const onMessageListeners = [];
+    window.__stillTestDispatchMessage = (msg) => {
+      for (const fn of onMessageListeners) {
+        try { fn(msg); } catch (e) { /* ignore */ }
+      }
+    };
     window.browser = {
       storage: {
         local: {
-          get(keys, cb) { cb(state); },
+          get(keys, cb) { cb(window.__stillTestState); },
           set() {}
         }
       },
       runtime: {
-        onMessage: { addListener() {} },
+        onMessage: { addListener(fn) { onMessageListeners.push(fn); } },
         sendMessage(msg) {
           if (msg && msg.type === 'headProbe' && hpct) {
             return Promise.resolve({ ok: true, status: 200, contentType: hpct });
@@ -361,11 +379,11 @@ test.describe('Still — block and replace logic', () => {
     expect(sheetText).toContain('.test-host-rule-target');
   });
 
-  test('per-host CSS rule pack — host-rules sheet is removed when the extension is disabled / site is allowlisted', async ({ page }) => {
-    // Regression for the bug where allowlisting a host-rules site (e.g.
-    // president.mit.edu) would leave the curtain bars permanently pinned at
-    // left:100% — checkState() removed the main __still-hide block but not
-    // __still-host-rules, so the page-level !important override stuck around.
+  test('per-host CSS rule pack — host-rules sheet is not injected when extension starts disabled', async ({ page }) => {
+    // Covers the inject-skip guard inside the host-rules .then() — the fetch
+    // resolves AFTER checkState() has already concluded enabled:false, so
+    // the guard is what prevents the sheet from landing in the DOM. (The
+    // checkState removal line is exercised by the next test.)
     await injectContentScript(page, {
       hostRulesURL: baseURL,
       initialState: { enabled: false, allowlist: [] },
@@ -373,12 +391,41 @@ test.describe('Still — block and replace logic', () => {
     await page.goto(baseURL + '/test-page.html');
     await page.addScriptTag({ path: CONTENT_SCRIPT });
 
-    // Once checkState() resolves with enabled:false, both the main style
-    // block AND the host-rules sheet should be gone from the DOM.
     await page.waitForFunction(() => {
       return !document.getElementById('__still-hide') &&
              !document.getElementById('__still-host-rules');
     }, { timeout: 5000 });
+  });
+
+  test('per-host CSS rule pack — host-rules sheet is removed when state flips to disabled', async ({ page }) => {
+    // Covers the cleanup path: extension starts enabled, the host-rules sheet
+    // gets injected, then the user toggles Still off (or allowlists the site).
+    // The stateChanged message handler triggers checkState(), which must
+    // remove BOTH __still-hide and __still-host-rules — otherwise the
+    // !important CSS override (e.g. .curtain-bar { left:100% }) stays pinned
+    // and the user keeps seeing the broken state on a site they just
+    // allowlisted to "let things through".
+    await injectContentScript(page, {
+      hostRulesURL: baseURL,
+      initialState: { enabled: true, allowlist: [] },
+    });
+    await page.goto(baseURL + '/test-page.html');
+    await page.addScriptTag({ path: CONTENT_SCRIPT });
+
+    // Wait for the host-rules sheet to actually appear (proves we're testing
+    // the cleanup path, not the inject-skip path).
+    await page.waitForFunction(() => !!document.getElementById('__still-host-rules'),
+      { timeout: 5000 });
+
+    // Flip state to disabled and dispatch the stateChanged message that the
+    // popup would normally send.
+    await page.evaluate(() => {
+      window.__stillTestState = { enabled: false, allowlist: [] };
+      window.__stillTestDispatchMessage({ type: 'stateChanged' });
+    });
+
+    await page.waitForFunction(() => !document.getElementById('__still-host-rules'),
+      { timeout: 5000 });
   });
 
   test('per-host CSS rule pack — bundled host-rules.json is well-formed and contains the MIT OP rule', async () => {
@@ -393,6 +440,44 @@ test.describe('Still — block and replace logic', () => {
     const joined = rules['president.mit.edu'].join('\n');
     expect(joined).toMatch(/\.curtain-bar/);
     expect(joined).toMatch(/!important/);
+  });
+
+  test('already-errored image with HEAD=unknown settles as static (does not hang visibility:hidden)', async ({ page }) => {
+    // Edge case from PR review: if the image has already errored
+    // (img.complete=true, img.naturalWidth=0) AND the HEAD probe returns
+    // 'unknown' (e.g. 404 here), the prior code added load/error listeners
+    // that would never fire — neither event re-triggers on a settled-error
+    // image — leaving the img visibility:hidden forever. Fix: when complete
+    // is true on entry to the unknown branch, classify immediately based on
+    // naturalWidth instead of waiting for events.
+    await injectContentScript(page);
+    await page.goto(baseURL + '/test-page.html');
+
+    await page.evaluate((base) => {
+      const img = document.createElement('img');
+      img.id = 'img-broken';
+      img.src = base + '/broken-image';  // server returns 404
+      document.body.appendChild(img);
+    }, baseURL);
+
+    // Wait for the image to actually error out before injecting content.js,
+    // so by the time scanAll runs the img is already complete + naturalWidth=0.
+    await page.waitForFunction(() => {
+      const img = document.getElementById('img-broken');
+      return img && img.complete && img.naturalWidth === 0;
+    }, { timeout: 5000 });
+
+    await page.addScriptTag({ path: CONTENT_SCRIPT });
+
+    // The fix should settle data-still to 'static' (and unhide). Without the
+    // fix, this stays at 'probing' until the test times out.
+    await page.waitForFunction(() => {
+      const img = document.getElementById('img-broken');
+      return img && img.dataset.still === 'static';
+    }, { timeout: 5000 });
+
+    const visibility = await page.$eval('#img-broken', el => getComputedStyle(el).visibility);
+    expect(visibility).not.toBe('hidden');
   });
 
   test('falls back to background HEAD probe when content-script fetch is CORS-blocked (newyorker.com pattern)', async ({ page }) => {

--- a/tests/motion/analyze.mts
+++ b/tests/motion/analyze.mts
@@ -71,7 +71,7 @@ for (const line of log.split('\n')) {
   // Accept scientific notation — on near-identical frames ffmpeg emits values
   // like `7.71484e-05`, and a [\d.]-only capture silently truncated the exponent
   // and read that as 7.71484 (a huge value from a numerically-zero diff).
-  const m = line.match(/lavfi\.signalstats\.YAVG=([-+eE\d.]+)/);
+  const m = line.match(/lavfi\.signalstats\.YAVG=([-+]?[\d]+(?:\.[\d]+)?(?:[eE][-+]?[\d]+)?)/);
   if (m && curFrame != null) scores.push({ t: curFrame, y: parseFloat(m[1]) });
 }
 if (useFrames) {

--- a/tests/motion/analyze.mts
+++ b/tests/motion/analyze.mts
@@ -3,7 +3,7 @@
 // Usage: tsx analyze.ts --in <dir>
 
 import { execFileSync } from 'node:child_process';
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 function arg(name: string): string | undefined;
@@ -30,6 +30,11 @@ const summary = join(dir, 'summary.json');
 // The PNG path is required for detecting sub-1-luminance signal (subpixel AA
 // jitter, slow tint drift) because VP8 quantization masks it.
 const useFrames = existsSync(framesDir) && existsSync(frameTimesFile);
+// Detect frame extension (record.mts --png-capture writes .png; CDP screencast
+// writes .jpg). Both use zero-padded %06d names.
+const frameExt = useFrames
+  ? (readdirSync(framesDir).find((f) => /\.(png|jpe?g)$/i.test(f))?.match(/\.(png|jpe?g)$/i)?.[0] || '.jpg')
+  : '.jpg';
 if (!useFrames && !existsSync(video)) {
   console.error('need recording.webm OR frames/ + frame_times.json in', dir);
   process.exit(1);
@@ -40,7 +45,7 @@ if (!useFrames && !existsSync(video)) {
 if (useFrames) {
   // Drive from the PNG sequence; ffmpeg's image2 demuxer walks the indexed names.
   execFileSync('ffmpeg', [
-    '-y', '-framerate', '10', '-i', join(framesDir, '%06d.png'),
+    '-y', '-framerate', '10', '-i', join(framesDir, `%06d${frameExt}`),
     '-vf', `tblend=all_mode=difference,signalstats,metadata=print:file=${metaLog}`,
     '-f', 'null', '-',
   ], { stdio: ['ignore', 'ignore', 'inherit'] });
@@ -85,7 +90,7 @@ writeFileSync(csvPath, csv + '\n');
 // same file each frame, so the final PNG is the accumulated motion map.
 if (useFrames) {
   execFileSync('ffmpeg', [
-    '-y', '-framerate', '10', '-i', join(framesDir, '%06d.png'),
+    '-y', '-framerate', '10', '-i', join(framesDir, `%06d${frameExt}`),
     '-vf', 'tblend=all_mode=difference,format=gray,lagfun=decay=1.0,eq=contrast=4',
     '-update', '1', '-frames:v', '99999', heatmap,
   ], { stdio: ['ignore', 'ignore', 'inherit'] });

--- a/tests/motion/analyze.mts
+++ b/tests/motion/analyze.mts
@@ -17,22 +17,45 @@ const inArg = arg('in');
 if (!inArg) { console.error('--in required'); process.exit(1); }
 const dir = resolve(inArg);
 const video = join(dir, 'recording.webm');
+const framesDir = join(dir, 'frames');
+const frameTimesFile = join(dir, 'frame_times.json');
 const metaLog = join(dir, 'motion.log');
 const csvPath = join(dir, 'motion.csv');
 const heatmap = join(dir, 'heatmap.png');
 const summary = join(dir, 'summary.json');
 
-if (!existsSync(video)) { console.error('no recording.webm in', dir); process.exit(1); }
+// Two input modes:
+//   A. WebM recording  (lossy VP8, 25fps, resampled to 10fps for analysis)
+//   B. PNG sequence    (lossless, written by record.mts --png-capture)
+// The PNG path is required for detecting sub-1-luminance signal (subpixel AA
+// jitter, slow tint drift) because VP8 quantization masks it.
+const useFrames = existsSync(framesDir) && existsSync(frameTimesFile);
+if (!useFrames && !existsSync(video)) {
+  console.error('need recording.webm OR frames/ + frame_times.json in', dir);
+  process.exit(1);
+}
 
-// Pass 1: per-frame YAVG of inter-frame difference @ 10fps.
+// Pass 1: per-frame YAVG of inter-frame difference.
 // tblend=difference gives |frame - prev|; signalstats publishes YAVG on that diff.
-execFileSync('ffmpeg', [
-  '-y', '-i', video,
-  '-vf', `fps=10,tblend=all_mode=difference,signalstats,metadata=print:file=${metaLog}`,
-  '-f', 'null', '-',
-], { stdio: ['ignore', 'ignore', 'inherit'] });
+if (useFrames) {
+  // Drive from the PNG sequence; ffmpeg's image2 demuxer walks the indexed names.
+  execFileSync('ffmpeg', [
+    '-y', '-framerate', '10', '-i', join(framesDir, '%06d.png'),
+    '-vf', `tblend=all_mode=difference,signalstats,metadata=print:file=${metaLog}`,
+    '-f', 'null', '-',
+  ], { stdio: ['ignore', 'ignore', 'inherit'] });
+} else {
+  execFileSync('ffmpeg', [
+    '-y', '-i', video,
+    '-vf', `fps=10,tblend=all_mode=difference,signalstats,metadata=print:file=${metaLog}`,
+    '-f', 'null', '-',
+  ], { stdio: ['ignore', 'ignore', 'inherit'] });
+}
 
 // Parse metadata log: lines like "lavfi.signalstats.YAVG=1.234"
+// The log's `pts_time` is relative to the ffmpeg stream. For PNG input that's
+// frame_index / framerate, not wall-clock capture time — we remap to the real
+// timestamps we wrote during capture so scroll masking stays correct.
 const log = readFileSync(metaLog, 'utf8');
 type Score = { t: number; y: number };
 const scores: Score[] = [];
@@ -43,6 +66,16 @@ for (const line of log.split('\n')) {
   const m = line.match(/lavfi\.signalstats\.YAVG=([\d.]+)/);
   if (m && curFrame != null) scores.push({ t: curFrame, y: parseFloat(m[1]) });
 }
+if (useFrames) {
+  const frameTimes: { idx: number; t: number }[] =
+    JSON.parse(readFileSync(frameTimesFile, 'utf8')).frameTimes;
+  // ffmpeg pts_time at 10fps is idx/10; signalstats emits one event per diff
+  // frame, so record i corresponds to captured frame i+1 (no diff for first).
+  for (let i = 0; i < scores.length; i++) {
+    const targetIdx = i + 1;
+    if (targetIdx < frameTimes.length) scores[i].t = frameTimes[targetIdx].t;
+  }
+}
 
 // Write CSV.
 const csv = ['t,motion', ...scores.map((s) => `${s.t.toFixed(3)},${s.y.toFixed(4)}`)].join('\n');
@@ -50,11 +83,19 @@ writeFileSync(csvPath, csv + '\n');
 
 // Pass 2: heatmap. lagfun with decay=1.0 keeps per-pixel max over time; -update 1 overwrites
 // same file each frame, so the final PNG is the accumulated motion map.
-execFileSync('ffmpeg', [
-  '-y', '-i', video,
-  '-vf', 'fps=10,tblend=all_mode=difference,format=gray,lagfun=decay=1.0,eq=contrast=4',
-  '-update', '1', '-frames:v', '99999', heatmap,
-], { stdio: ['ignore', 'ignore', 'inherit'] });
+if (useFrames) {
+  execFileSync('ffmpeg', [
+    '-y', '-framerate', '10', '-i', join(framesDir, '%06d.png'),
+    '-vf', 'tblend=all_mode=difference,format=gray,lagfun=decay=1.0,eq=contrast=4',
+    '-update', '1', '-frames:v', '99999', heatmap,
+  ], { stdio: ['ignore', 'ignore', 'inherit'] });
+} else {
+  execFileSync('ffmpeg', [
+    '-y', '-i', video,
+    '-vf', 'fps=10,tblend=all_mode=difference,format=gray,lagfun=decay=1.0,eq=contrast=4',
+    '-update', '1', '-frames:v', '99999', heatmap,
+  ], { stdio: ['ignore', 'ignore', 'inherit'] });
+}
 
 // Mask scroll moments (±0.4s around each scroll) so viewport motion doesn't count.
 const scrollFile = join(dir, 'scroll_times.json');
@@ -69,15 +110,13 @@ const ys = kept.map((s) => s.y);
 const sum = ys.reduce((a, b) => a + b, 0);
 const mean = ys.length ? sum / ys.length : 0;
 const max = ys.length ? Math.max(...ys) : 0;
-// Fraction of frames whose motion exceeds the VP8 encoder noise floor. Verified
-// empirically: at keyframe boundaries (~every 5s) we see motion=1.00 spikes, but
-// extracting those frames and pixel-diffing them shows byte-identical output
-// (i.e., compression quantization, not real content). 1.5 is a safe real-signal
-// threshold; anything under is encoder noise.
-const MOTION_FLOOR = 1.5;
+// Lossless PNG input has no encoder floor, so real signal can be much smaller.
+// For WebM we keep the 1.5-unit floor (VP8 keyframe noise); for PNG we drop to
+// 0.05 since any non-zero mean diff is a real pixel change.
+const MOTION_FLOOR = useFrames ? 0.05 : 1.5;
 const moving = ys.filter((v) => v > MOTION_FLOOR).length;
 const movingPct = ys.length ? moving / ys.length : 0;
 
-const result = { frames: ys.length, maskedScrollFrames: masked, meanMotion: +mean.toFixed(3), maxMotion: +max.toFixed(3), movingFramesPct: +(movingPct * 100).toFixed(1) };
+const result = { input: useFrames ? 'png' : 'webm', frames: ys.length, maskedScrollFrames: masked, meanMotion: +mean.toFixed(4), maxMotion: +max.toFixed(4), movingFramesPct: +(movingPct * 100).toFixed(1) };
 writeFileSync(summary, JSON.stringify(result, null, 2));
 console.log(JSON.stringify(result));

--- a/tests/motion/analyze.mts
+++ b/tests/motion/analyze.mts
@@ -69,8 +69,13 @@ const ys = kept.map((s) => s.y);
 const sum = ys.reduce((a, b) => a + b, 0);
 const mean = ys.length ? sum / ys.length : 0;
 const max = ys.length ? Math.max(...ys) : 0;
-// Fraction of frames with motion above a floor (0.5 YAVG ~ "something clearly moved").
-const moving = ys.filter((v) => v > 0.5).length;
+// Fraction of frames whose motion exceeds the VP8 encoder noise floor. Verified
+// empirically: at keyframe boundaries (~every 5s) we see motion=1.00 spikes, but
+// extracting those frames and pixel-diffing them shows byte-identical output
+// (i.e., compression quantization, not real content). 1.5 is a safe real-signal
+// threshold; anything under is encoder noise.
+const MOTION_FLOOR = 1.5;
+const moving = ys.filter((v) => v > MOTION_FLOOR).length;
 const movingPct = ys.length ? moving / ys.length : 0;
 
 const result = { frames: ys.length, maskedScrollFrames: masked, meanMotion: +mean.toFixed(3), maxMotion: +max.toFixed(3), movingFramesPct: +(movingPct * 100).toFixed(1) };

--- a/tests/motion/analyze.mts
+++ b/tests/motion/analyze.mts
@@ -68,7 +68,10 @@ let curFrame: number | null = null;
 for (const line of log.split('\n')) {
   const pts = line.match(/pts_time:([\d.]+)/);
   if (pts) curFrame = parseFloat(pts[1]);
-  const m = line.match(/lavfi\.signalstats\.YAVG=([\d.]+)/);
+  // Accept scientific notation — on near-identical frames ffmpeg emits values
+  // like `7.71484e-05`, and a [\d.]-only capture silently truncated the exponent
+  // and read that as 7.71484 (a huge value from a numerically-zero diff).
+  const m = line.match(/lavfi\.signalstats\.YAVG=([-+eE\d.]+)/);
   if (m && curFrame != null) scores.push({ t: curFrame, y: parseFloat(m[1]) });
 }
 if (useFrames) {

--- a/tests/motion/capture-display.mts
+++ b/tests/motion/capture-display.mts
@@ -51,6 +51,11 @@ const extArg = arg('ext');
 const extDir = extArg ? resolve(extArg) : null;
 const windowW = parseInt(arg('window-w', '1280'), 10);
 const windowH = parseInt(arg('window-h', '800'), 10);
+// Scroll-then-sit: scroll through 4 viewport positions with short pauses, then
+// sit for the remainder of the capture window. Captures in-view / lazy-load
+// animations that pure sit-mode misses. Scroll timestamps are recorded so the
+// analyzer can mask them.
+const scrollThenSit = process.argv.includes('--scroll-then-sit');
 
 mkdirSync(outDir, { recursive: true });
 const framesDir = join(outDir, 'frames');
@@ -99,15 +104,26 @@ writeFileSync(join(outDir, 'debug.json'), JSON.stringify({
 }, null, 2));
 
 // Start ffmpeg capturing the target avfoundation display. "INDEX:none" = video
-// from that display, no audio. We write JPG quality-2 (visually lossless) at
-// the requested framerate for `seconds` seconds, then stop.
+// from that display, no audio. A few macOS-specific details:
+//   - Virtual displays report a retina (2×) backing buffer, so a 2560×1440
+//     display comes out as 5120×2880 from avfoundation. We crop to Chrome's
+//     1280×800 point window (= 2560×1600 pixels at 2× scale) at the top-left
+//     of the display (Chrome was launched there), then scale to 1280×800 for
+//     storage + compat with our other analyzers.
+//   - Without -r on output, ffmpeg defaults to 1000fps VFR output and fills
+//     with tens of thousands of duplicate frames. -r <fps> forces CFR.
+//   - -pixel_format uyvy422 matches what avfoundation offers for screen caps.
+const cropPx = `${windowW * 2}:${windowH * 2}:0:0`; // 2× for retina backing
 const ffArgs = [
   '-hide_banner',
   '-f', 'avfoundation',
   '-framerate', String(fps),
+  '-pixel_format', 'uyvy422',
   '-capture_cursor', '0',
   '-i', `${avIndex}:none`,
   '-t', String(seconds),
+  '-vf', `crop=${cropPx},scale=${windowW}:${windowH}`,
+  '-r', String(fps),
   '-q:v', '2',
   '-f', 'image2',
   join(framesDir, '%06d.jpg'),
@@ -115,8 +131,29 @@ const ffArgs = [
 console.log('ffmpeg', ffArgs.join(' '));
 const tFfStart = Date.now();
 const ff = spawn('ffmpeg', ffArgs, { stdio: ['ignore', 'inherit', 'inherit'] });
-
 const done = new Promise<void>((res) => ff.on('exit', () => res()));
+
+// Concurrent workload: scroll pattern (if requested) while ffmpeg captures.
+// Scroll timestamps are in ffmpeg wall-clock (capture timeline) so the analyzer
+// masks them correctly. ffmpeg may take a few hundred ms to start producing
+// frames — our scroll timestamps will be slightly ahead of true frame-time,
+// but the ±0.4s mask window absorbs that.
+const scrollTimes: number[] = [];
+if (scrollThenSit) {
+  (async () => {
+    // Let ffmpeg settle briefly before first scroll.
+    await page.waitForTimeout(500);
+    const positions = [600, 1200, 1800, 2400];
+    for (const y of positions) {
+      const t = (Date.now() - tFfStart) / 1000;
+      scrollTimes.push(t);
+      try { await page.evaluate((yy) => window.scrollTo({ top: yy, behavior: 'instant' }), y); } catch {}
+      await page.waitForTimeout(1000);
+    }
+    // Remaining time of the capture window: just sit.
+  })().catch((e) => console.error('scroll workload error:', (e as Error).message));
+}
+
 await done;
 const tFfEnd = Date.now();
 const dt = (tFfEnd - tFfStart) / 1000;
@@ -129,5 +166,5 @@ await context.close();
 const frameFiles = readdirSync(framesDir).filter((f) => f.endsWith('.jpg')).sort();
 const frameTimes = frameFiles.map((_f, idx) => ({ idx, t: idx / fps }));
 writeFileSync(join(outDir, 'frame_times.json'), JSON.stringify({ frameTimes }, null, 2));
-writeFileSync(join(outDir, 'scroll_times.json'), JSON.stringify({ scrollTimes: [] }, null, 2));
+writeFileSync(join(outDir, 'scroll_times.json'), JSON.stringify({ scrollTimes }, null, 2));
 console.log(`captured ${frameFiles.length} frames in ${dt.toFixed(1)}s (~${(frameFiles.length / dt).toFixed(1)} fps)`);

--- a/tests/motion/capture-display.mts
+++ b/tests/motion/capture-display.mts
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Non-headless Chromium capture via macOS AVFoundation. Run Chrome positioned
+// on a BetterDisplay virtual display (or any invisible display), capture it
+// with ffmpeg at up to 60fps, feed the frames through variance.mts to detect
+// flicker that CDP screencast (capped at ~3fps in headless) cannot.
+//
+// Prereqs:
+//   - BetterDisplay or equivalent virtual display (no photons anywhere)
+//   - ffmpeg with avfoundation support (Homebrew build is fine)
+//   - Know your virtual display's AVFoundation index (see list-displays.sh)
+//   - Know the virtual display's macOS origin in pixel coords (--window-x/y)
+//
+// Usage: tsx capture-display.mts --url <url> --out <dir>
+//                                --av-index <N>       # avfoundation device number
+//                                --window-x <X> --window-y <Y>  # chrome position
+//                                [--seconds <n>] [--fps <n>]
+//                                [--cookies <json>] [--ext <ext-dir>]
+//                                [--window-w 1280] [--window-h 800]
+
+import { chromium as rawChromium, type Cookie, type Response } from '@playwright/test';
+import { addExtra } from 'playwright-extra';
+import StealthPlugin from 'puppeteer-extra-plugin-stealth';
+import { spawn } from 'node:child_process';
+import { mkdirSync, existsSync, writeFileSync, readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const chromium = addExtra(rawChromium);
+chromium.use(StealthPlugin());
+
+function arg(name: string): string | undefined;
+function arg(name: string, fallback: string): string;
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : fallback;
+}
+
+const url = arg('url');
+const outArg = arg('out');
+const avIndex = arg('av-index');
+const winX = arg('window-x');
+const winY = arg('window-y');
+if (!url || !outArg || !avIndex || !winX || !winY) {
+  console.error('required: --url --out --av-index --window-x --window-y');
+  process.exit(1);
+}
+const outDir = resolve(outArg);
+const seconds = parseInt(arg('seconds', '10'), 10);
+const fps = parseInt(arg('fps', '60'), 10);
+const cookiesFile = arg('cookies');
+const extArg = arg('ext');
+const extDir = extArg ? resolve(extArg) : null;
+const windowW = parseInt(arg('window-w', '1280'), 10);
+const windowH = parseInt(arg('window-h', '800'), 10);
+
+mkdirSync(outDir, { recursive: true });
+const framesDir = join(outDir, 'frames');
+mkdirSync(framesDir, { recursive: true });
+
+// Launch Chromium NON-headless at the target display's pixel coordinates.
+// Playwright forwards --window-position / --window-size to Chromium.
+const launchArgs = [
+  `--window-position=${winX},${winY}`,
+  `--window-size=${windowW},${windowH}`,
+  '--hide-scrollbars',
+  '--mute-audio',
+  // We rely on the OS to keep the compositor running at full rate since the
+  // window is on a "real" (virtual) display, not headless.
+];
+if (extDir) launchArgs.push(`--disable-extensions-except=${extDir}`, `--load-extension=${extDir}`);
+
+const context = await chromium.launchPersistentContext(join(outDir, '.userdata'), {
+  headless: false,
+  args: launchArgs,
+  viewport: { width: windowW, height: windowH },
+});
+
+if (cookiesFile && existsSync(cookiesFile)) {
+  const cookies: Cookie[] = JSON.parse(readFileSync(cookiesFile, 'utf8'));
+  for (const c of cookies) if (c.sameSite === 'None' && !c.secure) c.sameSite = 'Lax';
+  for (const c of cookies) { try { await context.addCookies([c]); } catch {} }
+}
+
+const page = await context.newPage();
+if (extDir) await page.waitForTimeout(1500);
+
+let nav: Response | null = null;
+try {
+  nav = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45000 });
+} catch (e) { console.error('goto failed:', (e as Error).message); }
+try {
+  await page.waitForFunction(() => (document.body?.innerText || '').length > 200, { timeout: 6000 });
+} catch {}
+
+writeFileSync(join(outDir, 'debug.json'), JSON.stringify({
+  status: nav ? nav.status() : null,
+  finalUrl: page.url(),
+  title: await page.title().catch(() => null),
+  bodyTextLength: await page.evaluate(() => (document.body?.innerText || '').length).catch(() => 0),
+}, null, 2));
+
+// Start ffmpeg capturing the target avfoundation display. "INDEX:none" = video
+// from that display, no audio. We write JPG quality-2 (visually lossless) at
+// the requested framerate for `seconds` seconds, then stop.
+const ffArgs = [
+  '-hide_banner',
+  '-f', 'avfoundation',
+  '-framerate', String(fps),
+  '-capture_cursor', '0',
+  '-i', `${avIndex}:none`,
+  '-t', String(seconds),
+  '-q:v', '2',
+  '-f', 'image2',
+  join(framesDir, '%06d.jpg'),
+];
+console.log('ffmpeg', ffArgs.join(' '));
+const tFfStart = Date.now();
+const ff = spawn('ffmpeg', ffArgs, { stdio: ['ignore', 'inherit', 'inherit'] });
+
+const done = new Promise<void>((res) => ff.on('exit', () => res()));
+await done;
+const tFfEnd = Date.now();
+const dt = (tFfEnd - tFfStart) / 1000;
+
+await page.close();
+await context.close();
+
+// Build frame_times.json assuming constant framerate. ffmpeg's image2 muxer
+// writes one frame per input tick, so idx/fps is the capture-relative time.
+const frameFiles = readdirSync(framesDir).filter((f) => f.endsWith('.jpg')).sort();
+const frameTimes = frameFiles.map((_f, idx) => ({ idx, t: idx / fps }));
+writeFileSync(join(outDir, 'frame_times.json'), JSON.stringify({ frameTimes }, null, 2));
+writeFileSync(join(outDir, 'scroll_times.json'), JSON.stringify({ scrollTimes: [] }, null, 2));
+console.log(`captured ${frameFiles.length} frames in ${dt.toFixed(1)}s (~${(frameFiles.length / dt).toFixed(1)} fps)`);

--- a/tests/motion/capture-display.mts
+++ b/tests/motion/capture-display.mts
@@ -56,6 +56,11 @@ const windowH = parseInt(arg('window-h', '800'), 10);
 // animations that pure sit-mode misses. Scroll timestamps are recorded so the
 // analyzer can mask them.
 const scrollThenSit = process.argv.includes('--scroll-then-sit');
+// Use the system Chrome binary (not Playwright's Chromium-for-Testing). Real
+// Chrome has a different TLS fingerprint that Cloudflare-protected sites like
+// axios.com require even with valid cookies. Channel 'chrome' is set up by
+// `npx playwright install chrome`.
+const useSystemChrome = process.argv.includes('--system-chrome');
 
 mkdirSync(outDir, { recursive: true });
 const framesDir = join(outDir, 'frames');
@@ -70,11 +75,15 @@ const launchArgs = [
   '--mute-audio',
   // We rely on the OS to keep the compositor running at full rate since the
   // window is on a "real" (virtual) display, not headless.
+  // Disable Chrome's `navigator.webdriver` exposure + automation banner so
+  // Cloudflare-style bot walls accept the session even with valid cookies.
+  '--disable-blink-features=AutomationControlled',
 ];
 if (extDir) launchArgs.push(`--disable-extensions-except=${extDir}`, `--load-extension=${extDir}`);
 
 const context = await chromium.launchPersistentContext(join(outDir, '.userdata'), {
   headless: false,
+  channel: useSystemChrome ? 'chrome' : undefined,
   args: launchArgs,
   viewport: { width: windowW, height: windowH },
 });

--- a/tests/motion/inspect.mts
+++ b/tests/motion/inspect.mts
@@ -14,7 +14,7 @@
 // Usage: tsx inspect.mts --in <report-dir> [--top 5]
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 function arg(name: string): string | undefined;
@@ -29,11 +29,34 @@ if (!inArg) { console.error('--in required'); process.exit(1); }
 const dir = resolve(inArg);
 const topN = parseInt(arg('top', '5'), 10);
 const video = join(dir, 'recording.webm');
+const framesDir = join(dir, 'frames');
+const frameTimesFile = join(dir, 'frame_times.json');
 const csvPath = join(dir, 'motion.csv');
 const scrollFile = join(dir, 'scroll_times.json');
 
-if (!existsSync(video) || !existsSync(csvPath)) {
-  console.error('need recording.webm and motion.csv in', dir); process.exit(1);
+const useFrames = existsSync(framesDir) && existsSync(frameTimesFile);
+if (!existsSync(csvPath) || (!useFrames && !existsSync(video))) {
+  console.error('need motion.csv plus either recording.webm or frames/+frame_times.json in', dir);
+  process.exit(1);
+}
+
+// If PNG sourced, build a (t → index) lookup so we can fetch the nearest captured
+// frame for any motion.csv timestamp.
+type FrameTime = { idx: number; t: number };
+const frameTimes: FrameTime[] = useFrames
+  ? JSON.parse(readFileSync(frameTimesFile, 'utf8')).frameTimes
+  : [];
+function nearestFrame(t: number): FrameTime {
+  let best = frameTimes[0];
+  let bestDelta = Math.abs(best.t - t);
+  for (const ft of frameTimes) {
+    const d = Math.abs(ft.t - t);
+    if (d < bestDelta) { best = ft; bestDelta = d; }
+  }
+  return best;
+}
+function pngPathForIdx(idx: number): string {
+  return join(framesDir, String(idx).padStart(6, '0') + '.png');
 }
 
 // Load scroll times (may be empty for sit-mode runs).
@@ -120,8 +143,22 @@ for (let i = 0; i < probes.length; i++) {
   const prev = join(frameDir, 'prev.png');
   const curr = join(frameDir, 'curr.png');
 
-  ff(['-ss', String(tPrev), '-i', video, '-frames:v', '1', prev]);
-  ff(['-ss', String(t), '-i', video, '-frames:v', '1', curr]);
+  if (useFrames) {
+    // Lossless path: pick the captured PNG for `curr` and its indexed predecessor
+    // for `prev`. Indexed predecessor is correct because that's exactly what
+    // analyze.mts diffed. Time-delta lookup would wrongly return the same frame
+    // when capture cadence is slower than prevOffset.
+    const currFt = nearestFrame(t);
+    // For baseline_first_vs_last, we want the predecessor to be at `firstSettled`
+    // (not idx-1), so honor a large prevOffset by using nearestFrame on tPrev.
+    const prevFt = prevOffset > 0.3 ? nearestFrame(tPrev) : frameTimes[Math.max(0, currFt.idx - 1)];
+    copyFileSync(pngPathForIdx(prevFt.idx), prev);
+    copyFileSync(pngPathForIdx(currFt.idx), curr);
+  } else {
+    // WebM path: seek via ffmpeg. Lossy by encoder, but fine for large motion.
+    ff(['-ss', String(tPrev), '-i', video, '-frames:v', '1', prev]);
+    ff(['-ss', String(t), '-i', video, '-frames:v', '1', curr]);
+  }
 
   // Luma diff (grayscale), contrast-amplified ×8 so subtle changes are visible.
   const diffLuma = join(frameDir, 'diff_luma.png');

--- a/tests/motion/inspect.mts
+++ b/tests/motion/inspect.mts
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// Inspect the top-motion frames of a recording. For each of the top N non-scroll
+// frames by motion score, produces:
+//   - prev.png / curr.png (the two frames being diffed)
+//   - diff_luma.png (grayscale luminance diff, contrast-amplified)
+//   - diff_r.png / diff_g.png / diff_b.png (per-channel diffs)
+//   - diff_chroma.png (UV-plane diff — catches pure hue shifts that luma misses)
+//   - hist.png (histogram of the luma diff — shows if change is concentrated in
+//     a few pixels with big deltas vs many pixels with tiny deltas)
+//   - stats.json (ffmpeg signalstats on each diff: YAVG, YMAX, counts)
+//
+// Writes a top-level inspect/summary.md tying it all together.
+//
+// Usage: tsx inspect.mts --in <report-dir> [--top 5]
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+function arg(name: string): string | undefined;
+function arg(name: string, fallback: string): string;
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : fallback;
+}
+
+const inArg = arg('in');
+if (!inArg) { console.error('--in required'); process.exit(1); }
+const dir = resolve(inArg);
+const topN = parseInt(arg('top', '5'), 10);
+const video = join(dir, 'recording.webm');
+const csvPath = join(dir, 'motion.csv');
+const scrollFile = join(dir, 'scroll_times.json');
+
+if (!existsSync(video) || !existsSync(csvPath)) {
+  console.error('need recording.webm and motion.csv in', dir); process.exit(1);
+}
+
+// Load scroll times (may be empty for sit-mode runs).
+const scrollTimes: number[] = existsSync(scrollFile)
+  ? JSON.parse(readFileSync(scrollFile, 'utf8')).scrollTimes
+  : [];
+const MASK = 0.4;
+const isScroll = (t: number) => scrollTimes.some((s) => Math.abs(t - s) < MASK);
+
+// Parse motion.csv, drop scroll frames, pick top N.
+const lines = readFileSync(csvPath, 'utf8').trim().split('\n').slice(1);
+type Row = { t: number; y: number };
+const rows: Row[] = lines.map((l) => {
+  const [t, y] = l.split(',').map(Number);
+  return { t, y };
+}).filter((r) => !isScroll(r.t));
+
+const top = rows.slice().sort((a, b) => b.y - a.y).slice(0, topN);
+
+const outRoot = join(dir, 'inspect');
+mkdirSync(outRoot, { recursive: true });
+
+function ff(args: string[]): void {
+  execFileSync('ffmpeg', ['-y', ...args], { stdio: ['ignore', 'ignore', 'inherit'] });
+}
+function ffOut(args: string[]): string {
+  return execFileSync('ffmpeg', ['-y', ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+// Run ffmpeg with metadata=print on a single file and parse one set of stats.
+// metadata=print writes to stderr, so capture it via spawnSync.
+function signalstats(pngPath: string): Record<string, number> {
+  const res = spawnSync('ffmpeg', [
+    '-y', '-i', pngPath,
+    '-vf', 'signalstats,metadata=print',
+    '-f', 'null', '-',
+  ], { encoding: 'utf8' });
+  const stats: Record<string, number> = {};
+  for (const line of (res.stderr || '').split('\n')) {
+    const m = line.match(/lavfi\.signalstats\.(\w+)=([\d.-]+)/);
+    if (m) stats[m[1]] = parseFloat(m[2]);
+  }
+  return stats;
+}
+
+type FrameReport = {
+  label: string;
+  t: number;
+  y: number;
+  prevOffset: number;
+  dir: string;
+  stats: {
+    luma: Record<string, number>;
+    r: Record<string, number>;
+    g: Record<string, number>;
+    b: Record<string, number>;
+    chroma: Record<string, number>;
+  };
+};
+
+const reports: FrameReport[] = [];
+
+// Long-baseline: first stable frame vs last frame. Catches slow drift that
+// frame-to-frame diffs miss (e.g., hue breathing over 30+ seconds).
+type Probe = { t: number; y: number; label: string; prevOffset: number };
+const probes: Probe[] = top.map((r, i) => ({ t: r.t, y: r.y, label: String(i + 1).padStart(2, '0'), prevOffset: 0.1 }));
+if (rows.length > 20) {
+  // Skip the first ~2s (initial render) and compare a settled frame to the last.
+  const firstSettled = rows.find((r) => r.t > 2.0);
+  const last = rows[rows.length - 1];
+  if (firstSettled && last && last.t > firstSettled.t + 1) {
+    probes.push({
+      t: last.t, y: last.y, label: 'baseline_first_vs_last',
+      prevOffset: last.t - firstSettled.t,
+    });
+  }
+}
+
+for (let i = 0; i < probes.length; i++) {
+  const { t, y, label, prevOffset } = probes[i];
+  const frameDir = join(outRoot, `${label}_t${t.toFixed(2)}`);
+  mkdirSync(frameDir, { recursive: true });
+  const tPrev = Math.max(0, t - prevOffset);
+  const prev = join(frameDir, 'prev.png');
+  const curr = join(frameDir, 'curr.png');
+
+  ff(['-ss', String(tPrev), '-i', video, '-frames:v', '1', prev]);
+  ff(['-ss', String(t), '-i', video, '-frames:v', '1', curr]);
+
+  // Luma diff (grayscale), contrast-amplified ×8 so subtle changes are visible.
+  const diffLuma = join(frameDir, 'diff_luma.png');
+  ff(['-i', prev, '-i', curr,
+      '-filter_complex', '[0:v][1:v]blend=all_mode=difference,format=gray,eq=contrast=8',
+      '-frames:v', '1', diffLuma]);
+
+  // Per-channel diffs. extractplanes gives us R, G, B planes as grayscale,
+  // then we diff same-plane-pairs.
+  function channelDiff(plane: 'r' | 'g' | 'b'): string {
+    const out = join(frameDir, `diff_${plane}.png`);
+    ff(['-i', prev, '-i', curr,
+        '-filter_complex',
+        `[0:v]format=rgb24,extractplanes=${plane}[a];` +
+        `[1:v]format=rgb24,extractplanes=${plane}[b];` +
+        `[a][b]blend=all_mode=difference,eq=contrast=8`,
+        '-frames:v', '1', out]);
+    return out;
+  }
+  const diffR = channelDiff('r');
+  const diffG = channelDiff('g');
+  const diffB = channelDiff('b');
+
+  // Chroma diff: difference of U+V planes (hue shift detector, independent of luma).
+  const diffChroma = join(frameDir, 'diff_chroma.png');
+  ff(['-i', prev, '-i', curr,
+      '-filter_complex',
+      '[0:v]format=yuv420p,extractplanes=u+v[au][av];' +
+      '[1:v]format=yuv420p,extractplanes=u+v[bu][bv];' +
+      '[au][bu]blend=all_mode=difference[du];' +
+      '[av][bv]blend=all_mode=difference[dv];' +
+      '[du][dv]vstack,eq=contrast=8',
+      '-frames:v', '1', diffChroma]);
+
+  // Histogram of the luma diff.
+  const hist = join(frameDir, 'hist.png');
+  ff(['-i', diffLuma,
+      '-vf', 'histogram=display_mode=stack',
+      '-update', '1', '-frames:v', '1', hist]);
+
+  const stats = {
+    luma: signalstats(diffLuma),
+    r: signalstats(diffR),
+    g: signalstats(diffG),
+    b: signalstats(diffB),
+    chroma: signalstats(diffChroma),
+  };
+  writeFileSync(join(frameDir, 'stats.json'), JSON.stringify(stats, null, 2));
+  reports.push({ label, t, y, prevOffset, dir: frameDir, stats });
+  console.log(`${label}: t=${t.toFixed(2)}s Δt=${prevOffset.toFixed(2)}s y=${y.toFixed(2)} → ${frameDir}`);
+}
+
+// Summary markdown.
+const lines2: string[] = [];
+lines2.push(`# Motion inspection — ${dir}`);
+lines2.push('');
+lines2.push(`Top ${reports.length} non-scroll moving frames. Stats are ffmpeg signalstats on the amplified diff image; YAVG=average brightness, YMAX=peak brightness (both 0–255). A high YAVG with low YMAX = scattered tiny shifts (tint/breathing). Low YAVG with high YMAX = localized flicker.`);
+lines2.push('');
+lines2.push('| label | t (s) | Δt (s) | motion | luma YAVG | luma YMAX | R avg | G avg | B avg | chroma avg |');
+lines2.push('|-------|------:|-------:|-------:|----------:|----------:|------:|------:|------:|-----------:|');
+for (const r of reports) {
+  const n = (x: number | undefined) => (x == null || Number.isNaN(x) ? '—' : x.toFixed(2));
+  lines2.push(`| ${r.label} | ${r.t.toFixed(2)} | ${r.prevOffset.toFixed(2)} | ${r.y.toFixed(2)} | ${n(r.stats.luma.YAVG)} | ${n(r.stats.luma.YMAX)} | ${n(r.stats.r.YAVG)} | ${n(r.stats.g.YAVG)} | ${n(r.stats.b.YAVG)} | ${n(r.stats.chroma.YAVG)} |`);
+}
+lines2.push('');
+lines2.push('Rows 01–N compare consecutive frames (Δt≈0.1s) — fast-moving content.');
+lines2.push('Row `baseline_first_vs_last` compares first settled frame to last — catches slow drift that frame-to-frame diffs miss.');
+lines2.push('');
+lines2.push('Per-frame artifacts in `inspect/<rank>_t<time>/`:');
+lines2.push('- `prev.png`, `curr.png` — the two compared frames');
+lines2.push('- `diff_luma.png` — amplified grayscale diff');
+lines2.push('- `diff_r.png`, `diff_g.png`, `diff_b.png` — per-channel RGB diffs');
+lines2.push('- `diff_chroma.png` — hue-shift detector (UV planes)');
+lines2.push('- `hist.png` — histogram of luma diff (many small vs few large pixels)');
+writeFileSync(join(outRoot, 'summary.md'), lines2.join('\n') + '\n');
+console.log(`\nwrote ${join(outRoot, 'summary.md')}`);

--- a/tests/motion/list-displays.sh
+++ b/tests/motion/list-displays.sh
@@ -6,22 +6,19 @@
 
 set -euo pipefail
 
-echo "=== macOS displays (from system_profiler) ==="
-system_profiler SPDisplaysDataType -json 2>/dev/null | python3 -c '
-import json, sys
-data = json.load(sys.stdin)
-for gpu in data.get("SPDisplaysDataType", []):
-    for d in gpu.get("spdisplays_ndrvs", []):
-        name = d.get("_name", "(unknown)")
-        res = d.get("_spdisplays_resolution", d.get("spdisplays_pixels", "?"))
-        origin = d.get("spdisplays_display_origin", "?")
-        main = " [MAIN]" if d.get("spdisplays_main") == "spdisplays_yes" else ""
-        mirror = " [MIRROR]" if d.get("spdisplays_mirror") == "spdisplays_yes" else ""
-        virtual = " [VIRTUAL]" if "virtual" in name.lower() or "betterdisplay" in name.lower() else ""
-        print(f"  name: {name}{main}{mirror}{virtual}")
-        print(f"    resolution: {res}")
-        print(f"    origin: {origin}")
-' 2>/dev/null || echo "  (could not parse system_profiler output)"
+echo "=== macOS displays (NSScreen origin + size) ==="
+# system_profiler doesn't surface coordinate origins reliably; a Swift one-liner
+# against NSScreen does. Bash-style heredoc piped into `swift -` runs inline.
+swift - <<'SWIFT_EOF' 2>/dev/null
+import Cocoa
+for screen in NSScreen.screens {
+  let f = screen.frame
+  let name = screen.localizedName
+  print("  name: \(name)")
+  print("    origin: (\(Int(f.origin.x)), \(Int(f.origin.y)))")
+  print("    size: \(Int(f.size.width))x\(Int(f.size.height))")
+}
+SWIFT_EOF
 
 echo ""
 echo "=== ffmpeg AVFoundation devices ==="

--- a/tests/motion/list-displays.sh
+++ b/tests/motion/list-displays.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Print connected displays with their macOS coordinate origins + sizes, and the
+# AVFoundation device indices ffmpeg uses to capture them. After creating a
+# virtual display in BetterDisplay, run this to find the right values to pass to
+# capture-display.mts.
+
+set -euo pipefail
+
+echo "=== macOS displays (from system_profiler) ==="
+system_profiler SPDisplaysDataType -json 2>/dev/null | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+for gpu in data.get("SPDisplaysDataType", []):
+    for d in gpu.get("spdisplays_ndrvs", []):
+        name = d.get("_name", "(unknown)")
+        res = d.get("_spdisplays_resolution", d.get("spdisplays_pixels", "?"))
+        origin = d.get("spdisplays_display_origin", "?")
+        main = " [MAIN]" if d.get("spdisplays_main") == "spdisplays_yes" else ""
+        mirror = " [MIRROR]" if d.get("spdisplays_mirror") == "spdisplays_yes" else ""
+        virtual = " [VIRTUAL]" if "virtual" in name.lower() or "betterdisplay" in name.lower() else ""
+        print(f"  name: {name}{main}{mirror}{virtual}")
+        print(f"    resolution: {res}")
+        print(f"    origin: {origin}")
+' 2>/dev/null || echo "  (could not parse system_profiler output)"
+
+echo ""
+echo "=== ffmpeg AVFoundation devices ==="
+ffmpeg -hide_banner -f avfoundation -list_devices true -i "" 2>&1 | grep -E '\[AVFoundation.*\] \[[0-9]+\]' || echo "  (ffmpeg not installed or no devices)"
+
+echo ""
+echo "Use the display origin (x,y) for --window-x / --window-y of capture-display.mts,"
+echo "and the AVFoundation index for --av-index (the numbers like [0], [1] in the second list)."

--- a/tests/motion/probe.mts
+++ b/tests/motion/probe.mts
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+// DOM-level animation probe. Loads a URL (no extension, same cookie/stealth setup
+// as record.mts), observes what mutates on the page over N seconds, and reports
+// which elements are animating, how (WAAPI / style / attribute / childList), and
+// where on the page they sit.
+//
+// Use after a sit-mode recording has shown motion, to identify the DOM culprit.
+// Optional --region x,y,w,h to filter results to a bounding box (e.g., the
+// region where the heatmap showed motion).
+//
+// Usage: tsx probe.mts --url <url> --out <dir> [--seconds <n>] [--cookies <json>]
+//                      [--region x,y,w,h]
+
+import { chromium as rawChromium, type Cookie, type Response } from '@playwright/test';
+import { addExtra } from 'playwright-extra';
+import StealthPlugin from 'puppeteer-extra-plugin-stealth';
+import { mkdirSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const chromium = addExtra(rawChromium);
+chromium.use(StealthPlugin());
+
+function arg(name: string): string | undefined;
+function arg(name: string, fallback: string): string;
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : fallback;
+}
+
+const url = arg('url');
+const outArg = arg('out');
+if (!url || !outArg) { console.error('--url and --out required'); process.exit(1); }
+const outDir = resolve(outArg);
+const seconds = parseInt(arg('seconds', '15'), 10);
+const cookiesFile = arg('cookies');
+const regionArg = arg('region');
+type Rect = { x: number; y: number; w: number; h: number };
+const region: Rect | null = regionArg
+  ? (() => { const [x, y, w, h] = regionArg.split(',').map(Number); return { x, y, w, h }; })()
+  : null;
+
+mkdirSync(outDir, { recursive: true });
+const viewport = { width: 1280, height: 800 };
+
+const context = await chromium.launchPersistentContext(join(outDir, '.userdata'), {
+  headless: false,
+  args: ['--headless=new', '--disable-gpu', '--hide-scrollbars', '--mute-audio'],
+  viewport,
+});
+
+// Install the probe BEFORE any page script runs. window.__probe captures all
+// mutations we care about; the page code can't remove it because the observer
+// is wired into every new document in this context.
+await context.addInitScript(() => {
+  type Mut = {
+    t: number;
+    type: string;
+    selector: string;
+    attrName: string | null;
+    rect: { x: number; y: number; w: number; h: number } | null;
+  };
+  const w = window as unknown as { __probe: { mutations: Mut[]; start: number } };
+  w.__probe = { mutations: [], start: Date.now() };
+
+  function shortSelector(el: Element): string {
+    const tag = el.tagName.toLowerCase();
+    const id = el.id ? '#' + el.id : '';
+    let cls = '';
+    if (typeof el.className === 'string' && el.className) {
+      cls = '.' + el.className.trim().split(/\s+/).slice(0, 3).join('.');
+    }
+    const data = Array.from(el.attributes).find((a) => a.name.startsWith('data-a-'))?.name;
+    return tag + id + cls + (data ? `[${data}]` : '');
+  }
+
+  const obs = new MutationObserver((records) => {
+    const t = (Date.now() - w.__probe.start) / 1000;
+    for (const r of records) {
+      const target = r.target as Element;
+      const rect = target instanceof Element ? (() => {
+        const b = target.getBoundingClientRect();
+        return { x: Math.round(b.x), y: Math.round(b.y), w: Math.round(b.width), h: Math.round(b.height) };
+      })() : null;
+      w.__probe.mutations.push({
+        t,
+        type: r.type,
+        selector: target instanceof Element ? shortSelector(target) : '#text',
+        attrName: r.attributeName || null,
+        rect,
+      });
+    }
+  });
+
+  // Filter to attributes that are actual motion signals; childList+subtree catches
+  // carousel slide swaps, lazy hydration, etc.
+  obs.observe(document.documentElement, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeFilter: ['style', 'class', 'src', 'srcset', 'aria-hidden', 'hidden'],
+  });
+});
+
+if (cookiesFile && existsSync(cookiesFile)) {
+  const cookies: Cookie[] = JSON.parse(readFileSync(cookiesFile, 'utf8'));
+  for (const c of cookies) if (c.sameSite === 'None' && !c.secure) c.sameSite = 'Lax';
+  for (const c of cookies) { try { await context.addCookies([c]); } catch {} }
+}
+
+const page = await context.newPage();
+let nav: Response | null = null;
+try {
+  nav = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45000 });
+} catch (e) { console.error('goto failed:', (e as Error).message); }
+try {
+  await page.waitForFunction(() => (document.body?.innerText || '').length > 200, { timeout: 6000 });
+} catch {}
+
+// Reset the probe clock: we only want to measure mutations that happen in the
+// steady-state window, not initial hydration.
+await page.evaluate(() => {
+  const w = window as unknown as { __probe: { mutations: unknown[]; start: number } };
+  w.__probe.mutations = [];
+  w.__probe.start = Date.now();
+});
+
+await page.waitForTimeout(seconds * 1000);
+
+type Mut = {
+  t: number; type: string; selector: string; attrName: string | null;
+  rect: { x: number; y: number; w: number; h: number } | null;
+};
+const mutations: Mut[] = await page.evaluate(() =>
+  (window as unknown as { __probe: { mutations: Mut[] } }).__probe.mutations
+);
+
+// WAAPI / CSS animations currently running.
+type Anim = { id: string; playState: string; target: string | null; keyframeCount: number };
+const animations: Anim[] = await page.evaluate(() =>
+  // Walk all shadow roots and the main document; `document.getAnimations()` by
+  // default only returns its own root, not descendants — pass {subtree:true}
+  // inside the page context where it's a supported call signature.
+  Array.from((document as Document & { getAnimations(o?: { subtree: boolean }): Animation[] }).getAnimations({ subtree: true })).map((a) => {
+    const effect = a.effect as KeyframeEffect | null;
+    const target = effect?.target as Element | null;
+    return {
+      id: a.id || '',
+      playState: a.playState,
+      target: target ? (target.tagName.toLowerCase() +
+        (target.id ? '#' + target.id : '') +
+        (typeof target.className === 'string' && target.className
+          ? '.' + target.className.trim().split(/\s+/).slice(0, 3).join('.') : '')) : null,
+      keyframeCount: effect?.getKeyframes?.().length ?? 0,
+    };
+  })
+);
+
+await page.screenshot({ path: join(outDir, 'probe-final.png'), fullPage: false }).catch(() => {});
+await page.close();
+await context.close();
+
+// Filter by region if provided.
+const inRegion = (m: Mut) => {
+  if (!region || !m.rect) return true;
+  const r = m.rect;
+  // Consider any overlap with the region as "in".
+  return r.x < region.x + region.w && r.x + r.w > region.x
+      && r.y < region.y + region.h && r.y + r.h > region.y;
+};
+const filtered = mutations.filter(inRegion);
+
+// Aggregate by selector: count mutations, split by type, carry representative rect.
+type Agg = {
+  selector: string; count: number;
+  byType: Record<string, number>;
+  byAttr: Record<string, number>;
+  rect: Mut['rect'];
+  firstT: number;
+  lastT: number;
+};
+const agg = new Map<string, Agg>();
+for (const m of filtered) {
+  let a = agg.get(m.selector);
+  if (!a) {
+    a = { selector: m.selector, count: 0, byType: {}, byAttr: {}, rect: m.rect, firstT: m.t, lastT: m.t };
+    agg.set(m.selector, a);
+  }
+  a.count++;
+  a.byType[m.type] = (a.byType[m.type] || 0) + 1;
+  if (m.attrName) a.byAttr[m.attrName] = (a.byAttr[m.attrName] || 0) + 1;
+  a.lastT = m.t;
+}
+const sorted = Array.from(agg.values()).sort((a, b) => b.count - a.count);
+
+writeFileSync(join(outDir, 'probe.json'), JSON.stringify({
+  url, seconds, region, totalMutations: mutations.length, filteredMutations: filtered.length,
+  animations, topSelectors: sorted.slice(0, 30),
+}, null, 2));
+
+// Summary markdown.
+const md: string[] = [];
+md.push(`# DOM probe — ${url}`);
+md.push('');
+md.push(`Observed **${seconds}s** of steady-state (post-hydration). `);
+md.push(`Total mutations: **${mutations.length}**${region ? ` (in region: ${filtered.length})` : ''}.`);
+md.push(`WAAPI/CSS animations running: **${animations.length}**.`);
+md.push('');
+md.push('## Top animating elements');
+md.push('');
+md.push('| selector | count | types | attrs | rect | first→last (s) |');
+md.push('|----------|------:|-------|-------|------|----------------|');
+for (const a of sorted.slice(0, 15)) {
+  const types = Object.entries(a.byType).map(([k, v]) => `${k}:${v}`).join(' ');
+  const attrs = Object.entries(a.byAttr).map(([k, v]) => `${k}:${v}`).join(' ') || '—';
+  const rect = a.rect ? `${a.rect.x},${a.rect.y} ${a.rect.w}×${a.rect.h}` : '—';
+  md.push(`| \`${a.selector}\` | ${a.count} | ${types} | ${attrs} | ${rect} | ${a.firstT.toFixed(1)}→${a.lastT.toFixed(1)} |`);
+}
+md.push('');
+if (animations.length) {
+  md.push('## Active WAAPI / CSS animations');
+  md.push('');
+  md.push('| target | playState | keyframes |');
+  md.push('|--------|-----------|----------:|');
+  for (const a of animations.slice(0, 20)) {
+    md.push(`| \`${a.target || '(anon)'}\` | ${a.playState} | ${a.keyframeCount} |`);
+  }
+  md.push('');
+}
+md.push('Full records in `probe.json`. Final viewport screenshot: `probe-final.png`.');
+
+writeFileSync(join(outDir, 'probe.md'), md.join('\n') + '\n');
+console.log(`wrote ${join(outDir, 'probe.md')}`);

--- a/tests/motion/probe.mts
+++ b/tests/motion/probe.mts
@@ -9,7 +9,11 @@
 // region where the heatmap showed motion).
 //
 // Usage: tsx probe.mts --url <url> --out <dir> [--seconds <n>] [--cookies <json>]
-//                      [--region x,y,w,h]
+//                      [--region x,y,w,h] [--include-load]
+//
+// --include-load: do NOT reset the mutation clock after hydration. Use this to
+// catch one-shot on-load flourishes (the reset is meant to isolate steady-state
+// motion from initial hydration churn, but that hides page-load animations).
 
 import { chromium as rawChromium, type Cookie, type Response } from '@playwright/test';
 import { addExtra } from 'playwright-extra';
@@ -34,6 +38,7 @@ const outDir = resolve(outArg);
 const seconds = parseInt(arg('seconds', '15'), 10);
 const cookiesFile = arg('cookies');
 const regionArg = arg('region');
+const includeLoad = process.argv.includes('--include-load');
 type Rect = { x: number; y: number; w: number; h: number };
 const region: Rect | null = regionArg
   ? (() => { const [x, y, w, h] = regionArg.split(',').map(Number); return { x, y, w, h }; })()
@@ -117,12 +122,55 @@ try {
 } catch {}
 
 // Reset the probe clock: we only want to measure mutations that happen in the
-// steady-state window, not initial hydration.
-await page.evaluate(() => {
-  const w = window as unknown as { __probe: { mutations: unknown[]; start: number } };
-  w.__probe.mutations = [];
-  w.__probe.start = Date.now();
-});
+// steady-state window, not initial hydration. Skipped when --include-load so
+// we can catch one-shot on-load flourishes that finish during hydration.
+if (!includeLoad) {
+  await page.evaluate(() => {
+    const w = window as unknown as { __probe: { mutations: unknown[]; start: number } };
+    w.__probe.mutations = [];
+    w.__probe.start = Date.now();
+  });
+}
+
+// Snapshot active animations as early as we can — on-load WAAPI/CSS animations
+// may finish before the main wait elapses. Captured in parallel with the main
+// observation window below.
+type EarlyAnim = {
+  target: string | null;
+  targetOuterHTML: string | null;
+  animationName: string | null;
+  playState: string;
+  currentTime: number | null;
+  duration: number | null;
+  delay: number | null;
+  iterations: number | null;
+  easing: string | null;
+  keyframes: Record<string, unknown>[];
+};
+const earlyAnimations: EarlyAnim[] = await page.evaluate(() =>
+  Array.from((document as Document & { getAnimations(o?: { subtree: boolean }): Animation[] }).getAnimations({ subtree: true })).map((a) => {
+    const effect = a.effect as KeyframeEffect | null;
+    const target = effect?.target as Element | null;
+    const timing = effect?.getComputedTiming?.();
+    const kfs = effect?.getKeyframes?.() ?? [];
+    const outer = target ? (target.outerHTML || '').slice(0, 200) : null;
+    return {
+      target: target ? (target.tagName.toLowerCase() +
+        (target.id ? '#' + target.id : '') +
+        (typeof target.className === 'string' && target.className
+          ? '.' + target.className.trim().split(/\s+/).slice(0, 3).join('.') : '')) : null,
+      targetOuterHTML: outer,
+      animationName: (a as Animation & { animationName?: string }).animationName || a.id || null,
+      playState: a.playState,
+      currentTime: typeof a.currentTime === 'number' ? a.currentTime : null,
+      duration: typeof timing?.duration === 'number' ? timing.duration : null,
+      delay: typeof timing?.delay === 'number' ? timing.delay : null,
+      iterations: typeof timing?.iterations === 'number' ? timing.iterations : null,
+      easing: (timing as { easing?: string })?.easing || null,
+      keyframes: kfs as unknown as Record<string, unknown>[],
+    };
+  })
+);
 
 await page.waitForTimeout(seconds * 1000);
 
@@ -193,8 +241,9 @@ for (const m of filtered) {
 const sorted = Array.from(agg.values()).sort((a, b) => b.count - a.count);
 
 writeFileSync(join(outDir, 'probe.json'), JSON.stringify({
-  url, seconds, region, totalMutations: mutations.length, filteredMutations: filtered.length,
-  animations, topSelectors: sorted.slice(0, 30),
+  url, seconds, region, includeLoad,
+  totalMutations: mutations.length, filteredMutations: filtered.length,
+  earlyAnimations, animations, topSelectors: sorted.slice(0, 30),
 }, null, 2));
 
 // Summary markdown.
@@ -216,8 +265,19 @@ for (const a of sorted.slice(0, 15)) {
   md.push(`| \`${a.selector}\` | ${a.count} | ${types} | ${attrs} | ${rect} | ${a.firstT.toFixed(1)}→${a.lastT.toFixed(1)} |`);
 }
 md.push('');
+if (earlyAnimations.length) {
+  md.push('## WAAPI / CSS animations at load (captured right after body-text ready)');
+  md.push('');
+  md.push('| target | playState | t/dur (ms) | keyframes |');
+  md.push('|--------|-----------|-----------:|----------:|');
+  for (const a of earlyAnimations.slice(0, 20)) {
+    const td = `${a.currentTime?.toFixed(0) ?? '?'}/${a.duration?.toFixed(0) ?? '?'}`;
+    md.push(`| \`${a.target || '(anon)'}\` | ${a.playState} | ${td} | ${a.keyframes} |`);
+  }
+  md.push('');
+}
 if (animations.length) {
-  md.push('## Active WAAPI / CSS animations');
+  md.push('## Active WAAPI / CSS animations (at end of observation window)');
   md.push('');
   md.push('| target | playState | keyframes |');
   md.push('|--------|-----------|----------:|');

--- a/tests/motion/record.mts
+++ b/tests/motion/record.mts
@@ -27,6 +27,19 @@ const extDir = extArg ? resolve(extArg) : null;
 const seconds = parseInt(arg('seconds', '30'), 10);
 const cookiesFile = arg('cookies');
 const noScroll = process.argv.includes('--no-scroll');
+// "scroll-then-sit" mode: scroll through a handful of viewport positions with
+// short pauses, then sit still for the rest of the duration. Catches animations
+// that are triggered by new content coming into view (IntersectionObserver-driven
+// carousels, lazy-loaded Lottie, in-view parallax) which idle sit-mode misses.
+const scrollThenSit = process.argv.includes('--scroll-then-sit');
+// PNG-capture mode: instead of a lossy VP8 WebM, write a PNG per tick. Losseless,
+// no chroma subsampling — required for detecting sub-1-luminance-unit signal
+// (subpixel AA jitter, slow hue drift). Only valid with --no-scroll for now.
+const pngCapture = process.argv.includes('--png-capture');
+if (pngCapture && !noScroll) {
+  console.error('--png-capture currently requires --no-scroll (sit mode)');
+  process.exit(1);
+}
 
 mkdirSync(outDir, { recursive: true });
 
@@ -55,7 +68,9 @@ const context = await chromium.launchPersistentContext(userDataDir, {
   headless: false,
   args: launchArgs,
   viewport,
-  recordVideo: { dir: outDir, size: viewport },
+  // Skip WebM in PNG-capture mode to halve the work and ensure no encoder
+  // interference with the screenshot stream.
+  ...(pngCapture ? {} : { recordVideo: { dir: outDir, size: viewport } }),
 });
 
 if (cookiesFile && existsSync(cookiesFile)) {
@@ -103,13 +118,47 @@ const debug = {
 writeFileSync(join(outDir, 'debug.json'), JSON.stringify(debug, null, 2));
 await page.screenshot({ path: join(outDir, 'debug-initial.png'), fullPage: false }).catch(() => {});
 
-// In scroll mode, scroll through the page to trigger lazy-loaded motion.
-// In --no-scroll mode, sit still — isolates pure ambient animation (no viewport
-// changes), producing a cleaner signal for "is this page animating?".
 const scrollTimes: number[] = [];
-if (noScroll) {
+if (pngCapture) {
+  // Lossless PNG capture loop at ~10fps best-effort. page.screenshot reads the
+  // compositor buffer via CDP without triggering a repaint, so this shouldn't
+  // itself cause motion. Frame timestamps are recorded relative to capture
+  // start (reset here so analysis lines up with captures, not page.goto).
+  const framesDir = join(outDir, 'frames');
+  mkdirSync(framesDir, { recursive: true });
+  const tCaptureStart = Date.now();
+  const frameTimes: { idx: number; t: number }[] = [];
+  const endAt = tCaptureStart + seconds * 1000;
+  let idx = 0;
+  while (Date.now() < endAt) {
+    const t = (Date.now() - tCaptureStart) / 1000;
+    const p = join(framesDir, String(idx).padStart(6, '0') + '.png');
+    await page.screenshot({ path: p, fullPage: false });
+    frameTimes.push({ idx, t });
+    idx++;
+    await page.waitForTimeout(100);
+  }
+  writeFileSync(join(outDir, 'frame_times.json'), JSON.stringify({ frameTimes }, null, 2));
+} else if (noScroll) {
+  // Pure sit: isolates ambient animation, no viewport changes.
   await page.waitForTimeout(seconds * 1000);
+} else if (scrollThenSit) {
+  // Scroll through 4 viewport positions with short pauses to trigger in-view
+  // animations, then sit still for the remaining budget. Any motion after the
+  // final scroll is settle-triggered animation (lazy carousels, parallax,
+  // IntersectionObserver callbacks) that idle sit-mode would never see.
+  const positions = [600, 1200, 1800, 2400];
+  const scrollPhase = 1.0; // 1s per scroll step
+  for (const y of positions) {
+    const t = (Date.now() - tVideoStart) / 1000;
+    scrollTimes.push(t);
+    await page.evaluate((yy) => window.scrollTo({ top: yy, behavior: 'instant' }), y);
+    await page.waitForTimeout(scrollPhase * 1000);
+  }
+  const sitBudget = Math.max(1, seconds - positions.length * scrollPhase);
+  await page.waitForTimeout(sitBudget * 1000);
 } else {
+  // Continuous-scroll mode: scroll every 3s for the full duration.
   const steps = Math.max(1, Math.floor(seconds / 3));
   for (let i = 0; i < steps; i++) {
     const t = (Date.now() - tVideoStart) / 1000;
@@ -123,12 +172,16 @@ writeFileSync(join(outDir, 'scroll_times.json'), JSON.stringify({ scrollTimes },
 await page.close();
 await context.close();
 
-// Playwright names the video with a random id; rename to recording.webm.
-const files = readdirSync(outDir).filter((f) => f.endsWith('.webm'));
-if (files.length) {
-  renameSync(join(outDir, files[0]), join(outDir, 'recording.webm'));
-  console.log('wrote', join(outDir, 'recording.webm'));
+if (pngCapture) {
+  console.log('wrote', join(outDir, 'frames'));
 } else {
-  console.error('no video produced');
-  process.exit(2);
+  // Playwright names the video with a random id; rename to recording.webm.
+  const files = readdirSync(outDir).filter((f) => f.endsWith('.webm'));
+  if (files.length) {
+    renameSync(join(outDir, files[0]), join(outDir, 'recording.webm'));
+    console.log('wrote', join(outDir, 'recording.webm'));
+  } else {
+    console.error('no video produced');
+    process.exit(2);
+  }
 }

--- a/tests/motion/record.mts
+++ b/tests/motion/record.mts
@@ -26,6 +26,7 @@ const extArg = arg('ext');
 const extDir = extArg ? resolve(extArg) : null;
 const seconds = parseInt(arg('seconds', '30'), 10);
 const cookiesFile = arg('cookies');
+const noScroll = process.argv.includes('--no-scroll');
 
 mkdirSync(outDir, { recursive: true });
 
@@ -86,24 +87,36 @@ try {
 } catch (e) {
   console.error('goto failed:', (e as Error).message);
 }
+// Wait for actual content — goto on a JS-challenge page returns immediately with
+// an empty body; we want the real page before starting the measurement window.
+// 6s is a reasonable upper bound for challenge → hydration to complete.
+try {
+  await page.waitForFunction(() => (document.body?.innerText || '').length > 200, { timeout: 6000 });
+} catch {}
 const debug = {
   status: nav ? nav.status() : null,
   finalUrl: page.url(),
   title: await page.title().catch(() => null),
+  bodyTextLength: await page.evaluate(() => (document.body?.innerText || '').length).catch(() => 0),
   bodyTextSample: await page.evaluate(() => (document.body?.innerText || '').slice(0, 300)).catch(() => null),
 };
 writeFileSync(join(outDir, 'debug.json'), JSON.stringify(debug, null, 2));
 await page.screenshot({ path: join(outDir, 'debug-initial.png'), fullPage: false }).catch(() => {});
 
-// Scroll through the page to trigger lazy-loaded motion. Timestamps are seconds
-// since newPage() so they line up with ffmpeg's pts_time on the recording.
+// In scroll mode, scroll through the page to trigger lazy-loaded motion.
+// In --no-scroll mode, sit still — isolates pure ambient animation (no viewport
+// changes), producing a cleaner signal for "is this page animating?".
 const scrollTimes: number[] = [];
-const steps = Math.max(1, Math.floor(seconds / 3));
-for (let i = 0; i < steps; i++) {
-  const t = (Date.now() - tVideoStart) / 1000;
-  scrollTimes.push(t);
-  await page.evaluate((y) => window.scrollTo({ top: y, behavior: 'instant' }), i * 600);
-  await page.waitForTimeout(3000);
+if (noScroll) {
+  await page.waitForTimeout(seconds * 1000);
+} else {
+  const steps = Math.max(1, Math.floor(seconds / 3));
+  for (let i = 0; i < steps; i++) {
+    const t = (Date.now() - tVideoStart) / 1000;
+    scrollTimes.push(t);
+    await page.evaluate((y) => window.scrollTo({ top: y, behavior: 'instant' }), i * 600);
+    await page.waitForTimeout(3000);
+  }
 }
 writeFileSync(join(outDir, 'scroll_times.json'), JSON.stringify({ scrollTimes }, null, 2));
 

--- a/tests/motion/run.sh
+++ b/tests/motion/run.sh
@@ -15,6 +15,12 @@
 #   MODE=sit-png ./run.sh <url> [sec]       # lossless PNG capture, sit mode:
 #                                           # catches sub-encoder-floor signal
 #                                           # (subpixel AA jitter, slow hue drift)
+#   MODE=flicker ./run.sh <url> [sec]       # CDP screencast + variance. Capped
+#                                           # at ~3fps in headless — slow-cycle
+#                                           # analysis only, not true flicker.
+#   AV_INDEX=N WINDOW_X=X WINDOW_Y=Y \
+#     MODE=flicker-real ./run.sh <url>      # true 60fps via AVFoundation capture
+#                                           # of a BetterDisplay virtual display
 #   REF=<git-ref> ./run.sh <url>            # compare against a specific ref
 #
 # SIT mode produces the purest "is this page animating?" signal — scrolling
@@ -91,6 +97,45 @@ case "$MODE" in
   sit-png)
     run_variant "none"    --no-scroll --png-capture
     run_variant "current" --no-scroll --png-capture --ext "$REPO_ROOT/web-extension"
+    ;;
+  flicker-real)
+    # True-compositor 60fps capture via AVFoundation, for a Chrome window
+    # running on a BetterDisplay virtual display (no photons anywhere).
+    # Requires env vars: AV_INDEX, WINDOW_X, WINDOW_Y (see list-displays.sh).
+    : "${AV_INDEX:?AV_INDEX required}"
+    : "${WINDOW_X:?WINDOW_X required}"
+    : "${WINDOW_Y:?WINDOW_Y required}"
+    for name in none current; do
+      ext_args=""
+      [ "$name" = "current" ] && ext_args="--ext $REPO_ROOT/web-extension"
+      vdir="$RUN_DIR/$name"
+      mkdir -p "$vdir"
+      echo ">> capture: $name"
+      npx tsx "$SCRIPT_DIR/capture-display.mts" \
+        --url "$URL" --out "$vdir" --seconds "$SECONDS_RUN" \
+        --av-index "$AV_INDEX" --window-x "$WINDOW_X" --window-y "$WINDOW_Y" \
+        ${COOKIES_ARGS[@]+"${COOKIES_ARGS[@]}"} $ext_args
+      echo ">> variance: $name"
+      npx tsx "$SCRIPT_DIR/variance.mts" --in "$vdir"
+      npx tsx "$SCRIPT_DIR/analyze.mts" --in "$vdir"
+    done
+    ;;
+  flicker)
+    # Fast path: headless CDP screencast + variance. Limited to ~3fps in headless;
+    # use flicker-real for the migraine-frequency detection.
+    for name in none current; do
+      ext_args=""
+      [ "$name" = "current" ] && ext_args="--ext $REPO_ROOT/web-extension"
+      vdir="$RUN_DIR/$name"
+      mkdir -p "$vdir"
+      echo ">> screencast: $name"
+      npx tsx "$SCRIPT_DIR/screencast.mts" --url "$URL" --out "$vdir" \
+        --seconds "$SECONDS_RUN" ${COOKIES_ARGS[@]+"${COOKIES_ARGS[@]}"} $ext_args
+      echo ">> variance: $name"
+      npx tsx "$SCRIPT_DIR/variance.mts" --in "$vdir"
+      # Also produce the ordinary motion.csv + heatmap for comparison.
+      npx tsx "$SCRIPT_DIR/analyze.mts" --in "$vdir"
+    done
     ;;
   compare|*)
     # Ensure ref worktree exists at $REF.

--- a/tests/motion/run.sh
+++ b/tests/motion/run.sh
@@ -10,6 +10,11 @@
 #   MODE=baseline ./run.sh <url>            # add a "no extension" run
 #   MODE=sit ./run.sh <url> [seconds]       # no scrolling: isolates ambient motion
 #   MODE=sit-sweep ./run.sh <url>           # sit at 5/15/60s: catches slow cycles
+#   MODE=scroll-sit ./run.sh <url> [sec]    # scroll through 4 positions, then sit:
+#                                           # catches in-view/lazy-load animations
+#   MODE=sit-png ./run.sh <url> [sec]       # lossless PNG capture, sit mode:
+#                                           # catches sub-encoder-floor signal
+#                                           # (subpixel AA jitter, slow hue drift)
 #   REF=<git-ref> ./run.sh <url>            # compare against a specific ref
 #
 # SIT mode produces the purest "is this page animating?" signal — scrolling
@@ -78,6 +83,14 @@ case "$MODE" in
       run_variant "none_${dur}s"    --no-scroll
       run_variant "current_${dur}s" --no-scroll --ext "$REPO_ROOT/web-extension"
     done
+    ;;
+  scroll-sit)
+    run_variant "none"    --scroll-then-sit
+    run_variant "current" --scroll-then-sit --ext "$REPO_ROOT/web-extension"
+    ;;
+  sit-png)
+    run_variant "none"    --no-scroll --png-capture
+    run_variant "current" --no-scroll --png-capture --ext "$REPO_ROOT/web-extension"
     ;;
   compare|*)
     # Ensure ref worktree exists at $REF.

--- a/tests/motion/run.sh
+++ b/tests/motion/run.sh
@@ -8,7 +8,13 @@
 #   ./run.sh <url> [seconds]                # compare HEAD vs main
 #   MODE=single ./run.sh <url>              # just current tree
 #   MODE=baseline ./run.sh <url>            # add a "no extension" run
+#   MODE=sit ./run.sh <url> [seconds]       # no scrolling: isolates ambient motion
+#   MODE=sit-sweep ./run.sh <url>           # sit at 5/15/60s: catches slow cycles
 #   REF=<git-ref> ./run.sh <url>            # compare against a specific ref
+#
+# SIT mode produces the purest "is this page animating?" signal — scrolling
+# otherwise dominates the score. Try different seconds values to catch
+# animations on different timescales (5s for fast loops, 30s for slow crossfades).
 #
 # Site cookies (for bypassing bot walls / auth): place a Playwright cookie
 # JSON at tests/motion/cookies/<hostname>.json — it will be auto-loaded when
@@ -59,6 +65,19 @@ case "$MODE" in
   baseline)
     run_variant "none"
     run_variant "current" --ext "$REPO_ROOT/web-extension"
+    ;;
+  sit)
+    run_variant "none" --no-scroll
+    run_variant "current" --no-scroll --ext "$REPO_ROOT/web-extension"
+    ;;
+  sit-sweep)
+    # Sit at three durations. Short (5s) catches fast loops; medium (15s) catches
+    # mid-cycle animations; long (60s) catches slow breathing/tint cycles.
+    for dur in 5 15 60; do
+      SECONDS_RUN="$dur"
+      run_variant "none_${dur}s"    --no-scroll
+      run_variant "current_${dur}s" --no-scroll --ext "$REPO_ROOT/web-extension"
+    done
     ;;
   compare|*)
     # Ensure ref worktree exists at $REF.

--- a/tests/motion/run.sh
+++ b/tests/motion/run.sh
@@ -21,6 +21,10 @@
 #   AV_INDEX=N WINDOW_X=X WINDOW_Y=Y \
 #     MODE=flicker-real ./run.sh <url>      # true 60fps via AVFoundation capture
 #                                           # of a BetterDisplay virtual display
+#   AV_INDEX=N WINDOW_X=X WINDOW_Y=Y \
+#     MODE=flicker-scroll ./run.sh <url>    # same, but scrolls through 4
+#                                           # positions first to surface lazy-
+#                                           # loaded / in-view animations
 #   REF=<git-ref> ./run.sh <url>            # compare against a specific ref
 #
 # SIT mode produces the purest "is this page animating?" signal — scrolling
@@ -98,13 +102,17 @@ case "$MODE" in
     run_variant "none"    --no-scroll --png-capture
     run_variant "current" --no-scroll --png-capture --ext "$REPO_ROOT/web-extension"
     ;;
-  flicker-real)
+  flicker-real|flicker-scroll)
     # True-compositor 60fps capture via AVFoundation, for a Chrome window
     # running on a BetterDisplay virtual display (no photons anywhere).
     # Requires env vars: AV_INDEX, WINDOW_X, WINDOW_Y (see list-displays.sh).
+    # flicker-scroll adds a 4-step scroll-then-sit workload concurrent with
+    # the capture — catches in-view / lazy-loaded animations.
     : "${AV_INDEX:?AV_INDEX required}"
     : "${WINDOW_X:?WINDOW_X required}"
     : "${WINDOW_Y:?WINDOW_Y required}"
+    scroll_flag=""
+    [ "$MODE" = "flicker-scroll" ] && scroll_flag="--scroll-then-sit"
     for name in none current; do
       ext_args=""
       [ "$name" = "current" ] && ext_args="--ext $REPO_ROOT/web-extension"
@@ -114,6 +122,7 @@ case "$MODE" in
       npx tsx "$SCRIPT_DIR/capture-display.mts" \
         --url "$URL" --out "$vdir" --seconds "$SECONDS_RUN" \
         --av-index "$AV_INDEX" --window-x "$WINDOW_X" --window-y "$WINDOW_Y" \
+        $scroll_flag \
         ${COOKIES_ARGS[@]+"${COOKIES_ARGS[@]}"} $ext_args
       echo ">> variance: $name"
       npx tsx "$SCRIPT_DIR/variance.mts" --in "$vdir"

--- a/tests/motion/screencast.mts
+++ b/tests/motion/screencast.mts
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// High-framerate recorder using Chrome DevTools Protocol's Page.startScreencast.
+// Captures JPEGs at ~30-60fps via WebSocket stream — required for detecting
+// 10-60 Hz pixel flicker that frame-to-frame analyzers miss.
+//
+// Lossless PNG is not a CDP screencast option; JPEG quality=95 is visually
+// near-lossless and catches flicker signal well. For pure subpixel-AA jitter
+// detection, use record.mts --png-capture (lossless but only ~5fps).
+//
+// Output layout matches record.mts so analyze.mts / inspect.mts / variance.mts
+// can all read it.
+//
+// Usage: tsx screencast.mts --url <url> --out <dir> [--seconds <n>]
+//                           [--cookies <json>] [--ext <extension-dir>]
+
+import { chromium as rawChromium, type Cookie, type Response } from '@playwright/test';
+import { addExtra } from 'playwright-extra';
+import StealthPlugin from 'puppeteer-extra-plugin-stealth';
+import { mkdirSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const chromium = addExtra(rawChromium);
+chromium.use(StealthPlugin());
+
+function arg(name: string): string | undefined;
+function arg(name: string, fallback: string): string;
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : fallback;
+}
+
+const url = arg('url');
+const outArg = arg('out');
+if (!url || !outArg) { console.error('--url and --out required'); process.exit(1); }
+const outDir = resolve(outArg);
+const seconds = parseInt(arg('seconds', '10'), 10);
+const cookiesFile = arg('cookies');
+const extArg = arg('ext');
+const extDir = extArg ? resolve(extArg) : null;
+const quality = parseInt(arg('quality', '95'), 10);
+
+mkdirSync(outDir, { recursive: true });
+const viewport = { width: 1280, height: 800 };
+
+// Flag soup required to get a real high-fps screencast in headless-new:
+//   - Keep GPU on: --disable-gpu drops compositor to ~2 fps.
+//   - disable-backgrounding-occluded-windows: prevents Chrome from pausing us
+//     because the window "isn't visible" (it never is — we're headless).
+//   - disable-renderer-backgrounding + disable-background-timer-throttling:
+//     keeps rAF running at full rate. Without these, rAF is clamped to ~1 Hz.
+const launchArgs = [
+  '--headless=new',
+  '--hide-scrollbars',
+  '--mute-audio',
+  '--disable-backgrounding-occluded-windows',
+  '--disable-renderer-backgrounding',
+  '--disable-background-timer-throttling',
+];
+if (extDir) {
+  launchArgs.push(`--disable-extensions-except=${extDir}`, `--load-extension=${extDir}`);
+}
+
+const context = await chromium.launchPersistentContext(join(outDir, '.userdata'), {
+  headless: false,
+  args: launchArgs,
+  viewport,
+});
+
+// Headless compositor only ticks when something "needs" painting. Without a
+// driver it produces ~2 fps during steady-state browsing, which is way below
+// what we need for flicker detection. Force the compositor to tick every frame
+// by mutating an offscreen element in a rAF loop. The element is fixed at
+// position -9999px so it never appears in the captured viewport — it does not
+// affect the measured pixels, only the paint cadence.
+await context.addInitScript(() => {
+  const el = document.createElement('div');
+  el.style.cssText = 'position:fixed;top:-9999px;left:-9999px;width:1px;height:1px;pointer-events:none;';
+  let toggled = false;
+  const install = () => {
+    if (!document.documentElement) return;
+    document.documentElement.appendChild(el);
+    const tick = () => {
+      toggled = !toggled;
+      el.style.opacity = toggled ? '0.999' : '1';
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  };
+  if (document.documentElement) install();
+  else document.addEventListener('DOMContentLoaded', install, { once: true });
+});
+
+if (cookiesFile && existsSync(cookiesFile)) {
+  const cookies: Cookie[] = JSON.parse(readFileSync(cookiesFile, 'utf8'));
+  for (const c of cookies) if (c.sameSite === 'None' && !c.secure) c.sameSite = 'Lax';
+  for (const c of cookies) { try { await context.addCookies([c]); } catch {} }
+}
+
+const page = await context.newPage();
+if (extDir) await page.waitForTimeout(1500);
+
+let nav: Response | null = null;
+try {
+  nav = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45000 });
+} catch (e) { console.error('goto failed:', (e as Error).message); }
+try {
+  await page.waitForFunction(() => (document.body?.innerText || '').length > 200, { timeout: 6000 });
+} catch {}
+
+writeFileSync(join(outDir, 'debug.json'), JSON.stringify({
+  status: nav ? nav.status() : null,
+  finalUrl: page.url(),
+  title: await page.title().catch(() => null),
+  bodyTextLength: await page.evaluate(() => (document.body?.innerText || '').length).catch(() => 0),
+}, null, 2));
+
+// Set up the screencast via CDP.
+const client = await context.newCDPSession(page);
+const framesDir = join(outDir, 'frames');
+mkdirSync(framesDir, { recursive: true });
+const frameTimes: { idx: number; t: number }[] = [];
+let idx = 0;
+const tStart = Date.now();
+let lastLog = tStart;
+
+// CDP emits screencastFrame events at ~the compositor rate (up to 60fps).
+// We MUST ACK each frame or the browser stops sending. The ACK is cheap, so the
+// rate is limited by WebSocket throughput + our disk write speed (fine on SSD).
+client.on('Page.screencastFrame', (frame: { data: string; sessionId: number; metadata?: { timestamp?: number } }) => {
+  const t = (Date.now() - tStart) / 1000;
+  const p = join(framesDir, String(idx).padStart(6, '0') + '.jpg');
+  writeFileSync(p, Buffer.from(frame.data, 'base64'));
+  frameTimes.push({ idx, t });
+  idx++;
+  // Fire-and-forget ack (don't await — keeps pipeline full).
+  client.send('Page.screencastFrameAck', { sessionId: frame.sessionId }).catch(() => {});
+  // Progress every second.
+  if (Date.now() - lastLog > 1000) {
+    const fps = idx / ((Date.now() - tStart) / 1000);
+    console.log(`  captured ${idx} frames (${fps.toFixed(1)} fps)`);
+    lastLog = Date.now();
+  }
+});
+
+await client.send('Page.startScreencast', {
+  format: 'jpeg',
+  quality,
+  maxWidth: viewport.width,
+  maxHeight: viewport.height,
+});
+
+await page.waitForTimeout(seconds * 1000);
+
+await client.send('Page.stopScreencast').catch(() => {});
+// Drain any in-flight frames briefly.
+await page.waitForTimeout(200);
+
+await page.close();
+await context.close();
+
+writeFileSync(join(outDir, 'frame_times.json'), JSON.stringify({ frameTimes }, null, 2));
+writeFileSync(join(outDir, 'scroll_times.json'), JSON.stringify({ scrollTimes: [] }, null, 2));
+const fpsTotal = frameTimes.length ? frameTimes.length / seconds : 0;
+console.log(`wrote ${frameTimes.length} frames (~${fpsTotal.toFixed(1)} fps) to ${framesDir}`);

--- a/tests/motion/variance.mts
+++ b/tests/motion/variance.mts
@@ -28,15 +28,31 @@ if (!inArg) { console.error('--in required'); process.exit(1); }
 const dir = resolve(inArg);
 const framesDir = join(dir, 'frames');
 const frameTimesFile = join(dir, 'frame_times.json');
+// Optional time window — for excluding the scrolling portion of a
+// scroll-then-sit recording so variance reflects only the post-settle period.
+const startT = parseFloat(arg('start-time', '0'));
+const endT = parseFloat(arg('end-time', '1e9'));
 if (!existsSync(framesDir) || !existsSync(frameTimesFile)) {
   console.error('need frames/ and frame_times.json in', dir); process.exit(1);
 }
 
-const frameFiles = readdirSync(framesDir)
+const frameTimesAll: { idx: number; t: number }[] =
+  JSON.parse(readFileSync(frameTimesFile, 'utf8')).frameTimes;
+const frameIdxInWindow = new Set(
+  frameTimesAll.filter((ft) => ft.t >= startT && ft.t <= endT).map((ft) => ft.idx)
+);
+const allFiles = readdirSync(framesDir)
   .filter((f) => /\.(jpe?g|png)$/i.test(f))
   .sort();
+const frameFiles = allFiles.filter((f) => {
+  const idx = parseInt(f.slice(0, 6), 10);
+  return frameIdxInWindow.size === 0 || frameIdxInWindow.has(idx);
+});
 if (frameFiles.length < 2) {
   console.error('need at least 2 frames; have', frameFiles.length); process.exit(1);
+}
+if (startT > 0 || endT < 1e9) {
+  console.log(`  window: t=${startT}s–${endT === 1e9 ? 'end' : endT + 's'} → ${frameFiles.length}/${allFiles.length} frames`);
 }
 
 console.log(`analyzing ${frameFiles.length} frames from ${framesDir}`);
@@ -100,9 +116,10 @@ for (let p = 0; p < pixelCount; p++) {
   if (sL > 2) highVarCount++;
 }
 
+const suffix = (startT > 0 || endT < 1e9) ? `_t${startT}-${endT}` : '';
 await sharp(Buffer.from(lumaStd.buffer), { raw: { width, height, channels: 1 } })
   .png()
-  .toFile(join(dir, 'variance_heatmap.png'));
+  .toFile(join(dir, `variance_heatmap${suffix}.png`));
 
 // Three-channel side-by-side image (R | G | B amplified std-dev).
 const rgbStack = Buffer.alloc(pixelCount * 3 * 3);
@@ -123,9 +140,10 @@ for (let y = 0; y < height; y++) {
 }
 await sharp(rgbStack, { raw: { width: width * 3, height, channels: 3 } })
   .png()
-  .toFile(join(dir, 'variance_rgb.png'));
+  .toFile(join(dir, `variance_rgb${suffix}.png`));
 
 const result = {
+  window: { startT, endT: endT === 1e9 ? null : endT },
   frames: n,
   meanLumaStd: +(sumLuma / pixelCount).toFixed(4),
   maxLumaStd: +maxLuma.toFixed(4),
@@ -133,5 +151,5 @@ const result = {
   highVariancePct: +(100 * highVarCount / pixelCount).toFixed(3),
   amplification: AMP,
 };
-writeFileSync(join(dir, 'variance.json'), JSON.stringify(result, null, 2));
+writeFileSync(join(dir, `variance${suffix}.json`), JSON.stringify(result, null, 2));
 console.log('\n' + JSON.stringify(result, null, 2));

--- a/tests/motion/variance.mts
+++ b/tests/motion/variance.mts
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+// Per-pixel temporal-variance analyzer. For each pixel location in the recording,
+// compute the standard deviation of its luminance across all captured frames.
+// High per-pixel std-dev = the pixel flickers over time — the signature of
+// sustained 10-60 Hz motion that migraine-sensitive eyes pick up even when
+// individual frame diffs look tiny.
+//
+// Produces:
+//   - variance_heatmap.png  (per-pixel std-dev, amplified for visibility)
+//   - variance_rgb.png      (three-channel std-dev: R/G/B side by side)
+//   - variance.json         (summary stats: mean/max std-dev, % high-variance pixels)
+//
+// Usage: tsx variance.mts --in <dir>
+
+import { readdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import sharp from 'sharp';
+
+function arg(name: string): string | undefined;
+function arg(name: string, fallback: string): string;
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : fallback;
+}
+
+const inArg = arg('in');
+if (!inArg) { console.error('--in required'); process.exit(1); }
+const dir = resolve(inArg);
+const framesDir = join(dir, 'frames');
+const frameTimesFile = join(dir, 'frame_times.json');
+if (!existsSync(framesDir) || !existsSync(frameTimesFile)) {
+  console.error('need frames/ and frame_times.json in', dir); process.exit(1);
+}
+
+const frameFiles = readdirSync(framesDir)
+  .filter((f) => /\.(jpe?g|png)$/i.test(f))
+  .sort();
+if (frameFiles.length < 2) {
+  console.error('need at least 2 frames; have', frameFiles.length); process.exit(1);
+}
+
+console.log(`analyzing ${frameFiles.length} frames from ${framesDir}`);
+
+// First frame: learn dimensions.
+const firstRaw = await sharp(join(framesDir, frameFiles[0])).raw().toBuffer({ resolveWithObject: true });
+const { width, height, channels } = firstRaw.info;
+const pixelCount = width * height;
+console.log(`  dims: ${width}×${height} (${channels} channels)`);
+
+// Running accumulators per channel. Float64 to avoid overflow on sum-of-squares
+// (a single pixel's value² = up to 65025; 600 frames → 39M, fits comfortably).
+const sumR = new Float64Array(pixelCount);
+const sumG = new Float64Array(pixelCount);
+const sumB = new Float64Array(pixelCount);
+const sqR = new Float64Array(pixelCount);
+const sqG = new Float64Array(pixelCount);
+const sqB = new Float64Array(pixelCount);
+
+let n = 0;
+for (const f of frameFiles) {
+  const { data, info } = await sharp(join(framesDir, f)).raw().toBuffer({ resolveWithObject: true });
+  if (info.width !== width || info.height !== height) continue; // skip any odd frame
+  // data is Uint8 interleaved RGB(A). Channels may be 3 or 4.
+  const ch = info.channels;
+  for (let i = 0, p = 0; i < data.length; i += ch, p++) {
+    const r = data[i], g = data[i + 1], b = data[i + 2];
+    sumR[p] += r; sumG[p] += g; sumB[p] += b;
+    sqR[p] += r * r; sqG[p] += g * g; sqB[p] += b * b;
+  }
+  n++;
+  if (n % 50 === 0) console.log(`  ${n}/${frameFiles.length}`);
+}
+
+// Per-pixel std-dev and amplified heatmaps.
+// var = E[X²] - E[X]²  → σ = sqrt(var)
+const lumaStd = new Uint8Array(pixelCount);
+const rStd = new Uint8Array(pixelCount);
+const gStd = new Uint8Array(pixelCount);
+const bStd = new Uint8Array(pixelCount);
+
+let maxLuma = 0, sumLuma = 0;
+let highVarCount = 0; // pixels with σ > 2 (i.e., clearly flickering above noise)
+const AMP = 8;
+for (let p = 0; p < pixelCount; p++) {
+  const mR = sumR[p] / n, mG = sumG[p] / n, mB = sumB[p] / n;
+  const vR = Math.max(0, sqR[p] / n - mR * mR);
+  const vG = Math.max(0, sqG[p] / n - mG * mG);
+  const vB = Math.max(0, sqB[p] / n - mB * mB);
+  const sR = Math.sqrt(vR), sG = Math.sqrt(vG), sB = Math.sqrt(vB);
+  // Luma approx (Rec.601): 0.299 R + 0.587 G + 0.114 B. Apply to std-dev as a
+  // scalar — not strictly correct (variance of a linear combination ≠ weighted
+  // sum of component std-devs) but close enough for visualization.
+  const sL = 0.299 * sR + 0.587 * sG + 0.114 * sB;
+  lumaStd[p] = Math.min(255, Math.round(sL * AMP));
+  rStd[p]    = Math.min(255, Math.round(sR * AMP));
+  gStd[p]    = Math.min(255, Math.round(sG * AMP));
+  bStd[p]    = Math.min(255, Math.round(sB * AMP));
+  if (sL > maxLuma) maxLuma = sL;
+  sumLuma += sL;
+  if (sL > 2) highVarCount++;
+}
+
+await sharp(Buffer.from(lumaStd.buffer), { raw: { width, height, channels: 1 } })
+  .png()
+  .toFile(join(dir, 'variance_heatmap.png'));
+
+// Three-channel side-by-side image (R | G | B amplified std-dev).
+const rgbStack = Buffer.alloc(pixelCount * 3 * 3);
+// Fill the three panels column-major: r in cols 0..w-1, g in w..2w-1, b in 2w..3w-1.
+for (let y = 0; y < height; y++) {
+  for (let x = 0; x < width; x++) {
+    const srcIdx = y * width + x;
+    rgbStack[(y * (3 * width) + x) * 3 + 0] = rStd[srcIdx];
+    rgbStack[(y * (3 * width) + x) * 3 + 1] = rStd[srcIdx];
+    rgbStack[(y * (3 * width) + x) * 3 + 2] = rStd[srcIdx];
+    rgbStack[(y * (3 * width) + x + width) * 3 + 0] = gStd[srcIdx];
+    rgbStack[(y * (3 * width) + x + width) * 3 + 1] = gStd[srcIdx];
+    rgbStack[(y * (3 * width) + x + width) * 3 + 2] = gStd[srcIdx];
+    rgbStack[(y * (3 * width) + x + 2 * width) * 3 + 0] = bStd[srcIdx];
+    rgbStack[(y * (3 * width) + x + 2 * width) * 3 + 1] = bStd[srcIdx];
+    rgbStack[(y * (3 * width) + x + 2 * width) * 3 + 2] = bStd[srcIdx];
+  }
+}
+await sharp(rgbStack, { raw: { width: width * 3, height, channels: 3 } })
+  .png()
+  .toFile(join(dir, 'variance_rgb.png'));
+
+const result = {
+  frames: n,
+  meanLumaStd: +(sumLuma / pixelCount).toFixed(4),
+  maxLumaStd: +maxLuma.toFixed(4),
+  highVariancePixels: highVarCount,
+  highVariancePct: +(100 * highVarCount / pixelCount).toFixed(3),
+  amplification: AMP,
+};
+writeFileSync(join(dir, 'variance.json'), JSON.stringify(result, null, 2));
+console.log('\n' + JSON.stringify(result, null, 2));

--- a/web-extension/background.js
+++ b/web-extension/background.js
@@ -139,6 +139,25 @@ api.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     return;
   }
 
+  if (msg.type === 'headProbe') {
+    // Cross-origin HEAD probe on behalf of a content script.
+    // Content-script `fetch` is bound by page CORS, so HEAD requests against
+    // CDN-hosted images (e.g. media.newyorker.com/.../undefined animated GIFs
+    // delivered without Access-Control-Allow-Origin) reject with TypeError —
+    // and Path E ends up marking the image static, leaking the animation.
+    // The service worker fetches in the extension's own origin context with
+    // the manifest's host_permissions, so it can read response headers for
+    // any URL we're authorized for.
+    fetch(msg.url, { method: 'HEAD', credentials: 'omit' })
+      .then((res) => sendResponse({
+        ok: res.ok,
+        status: res.status,
+        contentType: res.headers.get('content-type') || '',
+      }))
+      .catch((e) => sendResponse({ ok: false, error: String(e) }));
+    return true; // async response
+  }
+
   if (msg.type === 'getState') {
     storageGet(['enabled', 'allowlist']).then((result) => {
       const host = msg.host || '';

--- a/web-extension/background.js
+++ b/web-extension/background.js
@@ -148,6 +148,14 @@ api.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     // The service worker fetches in the extension's own origin context with
     // the manifest's host_permissions, so it can read response headers for
     // any URL we're authorized for.
+    //
+    // Defense-in-depth: only allow http(s). A malicious page setting
+    // `<img src="javascript:...">` or `<img src="file://...">` would
+    // otherwise hand us a privileged fetch we have no business making.
+    if (typeof msg.url !== 'string' || !/^https?:\/\//i.test(msg.url)) {
+      sendResponse({ ok: false, error: 'invalid url' });
+      return true;
+    }
     fetch(msg.url, { method: 'HEAD', credentials: 'omit' })
       .then((res) => sendResponse({
         ok: res.ok,

--- a/web-extension/content.js
+++ b/web-extension/content.js
@@ -273,30 +273,59 @@
   // interstitial returning text/html with status 403 before the page passes
   // verification). Caller should defer the decision in that case.
 
+  function classifyByContentType(rawCt) {
+    const ct = (rawCt || '').toLowerCase();
+    if (ct.includes('image/gif')) return 'animated';
+    if (ct.includes('image/jpeg') || ct.includes('image/svg') ||
+        ct.includes('image/bmp') || ct.includes('image/avif')) return 'static';
+    if (ct.includes('image/webp') || ct.includes('image/png') || ct.includes('image/apng')) return 'frame-data';
+    return 'unknown';
+  }
+
+  function probeViaBackground(url) {
+    // Content-script fetch is bound by page CORS, so cross-origin CDN URLs
+    // without Access-Control-Allow-Origin reject with TypeError. The service
+    // worker runs in the extension's own origin and uses our manifest
+    // host_permissions, so it can read response headers for any URL we're
+    // authorized for. Used as a fallback when the local HEAD throws.
+    // (newyorker.com homepage is the canonical case — animated GIFs are
+    // served from media.newyorker.com via URLs ending in `/undefined`.)
+    try {
+      const p = api.runtime.sendMessage({ type: 'headProbe', url });
+      if (!p || typeof p.then !== 'function') return Promise.resolve('unknown');
+      return p.then((response) => {
+        if (!response || !response.ok) return 'unknown';
+        const cls = classifyByContentType(response.contentType);
+        // 'frame-data' means we'd need byte-level inspection (animated WebP /
+        // APNG marker) — that's also a cross-origin range fetch we can't do
+        // from the content script, and we don't currently round-trip the
+        // bytes through the service worker. Treat as unknown for now.
+        return cls === 'frame-data' ? 'unknown' : cls;
+      }).catch(() => 'unknown');
+    } catch (e) {
+      return Promise.resolve('unknown');
+    }
+  }
+
   function detectAnimationForExtensionless(url) {
     return fetch(url, { method: 'HEAD', credentials: 'omit' })
       .then((res) => {
         if (!res.ok) return 'unknown';
-        const ct = (res.headers.get('content-type') || '').toLowerCase();
-        if (ct.includes('image/gif')) return 'animated';
-        if (ct.includes('image/jpeg') || ct.includes('image/svg') ||
-            ct.includes('image/bmp') || ct.includes('image/avif')) return 'static';
-        // WebP/APNG could be either — need to check the bytes
-        if (ct.includes('image/webp') || ct.includes('image/png') || ct.includes('image/apng')) {
-          return fetch(url, {
-            credentials: 'omit',
-            headers: { 'Range': 'bytes=0-4095' }
+        const cls = classifyByContentType(res.headers.get('content-type'));
+        if (cls !== 'frame-data') return cls;
+        // WebP / APNG / non-animated PNG: need byte-level inspection.
+        return fetch(url, {
+          credentials: 'omit',
+          headers: { 'Range': 'bytes=0-4095' }
+        })
+          .then((res2) => res2.arrayBuffer())
+          .then((buf) => {
+            const bytes = new Uint8Array(buf);
+            return (isAnimatedWebPBuffer(bytes) || isAnimatedPNGBuffer(bytes)) ? 'animated' : 'static';
           })
-            .then((res2) => res2.arrayBuffer())
-            .then((buf) => {
-              const bytes = new Uint8Array(buf);
-              return (isAnimatedWebPBuffer(bytes) || isAnimatedPNGBuffer(bytes)) ? 'animated' : 'static';
-            })
-            .catch(() => 'unknown');
-        }
-        return 'unknown';
+          .catch(() => 'unknown');
       })
-      .catch(() => 'unknown');
+      .catch(() => probeViaBackground(url));
   }
 
   // --- Spacer detection ---

--- a/web-extension/content.js
+++ b/web-extension/content.js
@@ -141,6 +141,12 @@
           img.style.visibility = '';
         });
       } else {
+        // Note: init() short-circuits via `initialized` after its first run,
+        // so flipping disabled→enabled on the same page won't re-inject
+        // `style`, the host-rules sheet, or re-scan for missed images. The
+        // popup's expected UX is "toggle requires reload to take effect" and
+        // this preserves that. If we ever want hot re-enable, init() and the
+        // host-rules injector would both need to be made idempotent.
         init();
       }
     });
@@ -505,9 +511,14 @@
         // decision until the image actually loads — by then the resource is
         // definitely fetchable, and a fresh HEAD will return real headers.
         const retry = () => detectAnimationForExtensionless(src).then(apply);
-        if (img.complete && img.naturalWidth > 0) {
-          // Image already loaded between HEAD failing and now — retry now.
-          retry();
+        if (img.complete) {
+          // Image is already done loading. Either it succeeded
+          // (naturalWidth > 0 → retry the HEAD now that the resource is
+          // definitely live) or it errored (naturalWidth === 0 → no
+          // future load/error event will fire, so settle as static now;
+          // otherwise the image would stay visibility:hidden forever).
+          if (img.naturalWidth > 0) retry();
+          else apply('static');
         } else {
           img.addEventListener('load', retry, { once: true });
           img.addEventListener('error', () => apply('static'), { once: true });

--- a/web-extension/content.js
+++ b/web-extension/content.js
@@ -83,6 +83,12 @@
       .then((rules) => {
         const list = rules[location.hostname];
         if (!list || !list.length) return;
+        // checkState() is async and may have run before this fetch resolves.
+        // If it concluded the extension is disabled / site is allowlisted,
+        // skip the inject — otherwise the sheet would land in the DOM after
+        // the cleanup pass and stick around forever (e.g. allowlisting
+        // president.mit.edu would still pin curtain bars at left:100%).
+        if (!enabled || siteAllowed) return;
         const sheet = document.createElement('style');
         sheet.id = '__still-host-rules';
         sheet.textContent = list.join('\n');
@@ -125,6 +131,11 @@
 
       if (!enabled || siteAllowed) {
         style.remove();
+        // Also drop the per-host CSS rule pack — otherwise allowlisting a
+        // site that has a host-rules entry (e.g. president.mit.edu) would
+        // leave the curtain bars permanently pinned at left:100%, since the
+        // !important rule keeps overriding the page's inline-style writes.
+        document.getElementById('__still-host-rules')?.remove();
         document.querySelectorAll('img[data-still="replacing"]').forEach((img) => {
           img.dataset.still = '';
           img.style.visibility = '';

--- a/web-extension/content.js
+++ b/web-extension/content.js
@@ -67,6 +67,30 @@
 
   const api = typeof browser !== 'undefined' ? browser : chrome;
 
+  // --- Per-host CSS rule pack ---
+  // host-rules.json is a curated list of `!important` CSS overrides for sites
+  // where our general defenses don't catch all motion (e.g. JS-driven jQuery
+  // animations against elements with predictable class names — see
+  // president.mit.edu's `.curtain-bar`). Rules are pinned with `!important`
+  // so they beat any inline styles the page's animation library writes per
+  // frame — the animation still "runs", but each frame's value is overridden
+  // before paint, so nothing visibly moves. Async-loaded but applied before
+  // the kinds of animations we target typically fire (jQuery animate triggers
+  // on image-load events, hundreds of ms after document_start).
+  if (api.runtime && typeof api.runtime.getURL === 'function') {
+    fetch(api.runtime.getURL('host-rules.json'))
+      .then((r) => r.json())
+      .then((rules) => {
+        const list = rules[location.hostname];
+        if (!list || !list.length) return;
+        const sheet = document.createElement('style');
+        sheet.id = '__still-host-rules';
+        sheet.textContent = list.join('\n');
+        (document.head || document.documentElement).appendChild(sheet);
+      })
+      .catch(() => {});
+  }
+
   // --- Helpers: wrap callback APIs to handle both Promise (Safari) and callback (Chrome) ---
 
   function storageGet(keys) {

--- a/web-extension/content.js
+++ b/web-extension/content.js
@@ -243,17 +243,20 @@
   }
 
   // --- Detect animation for extensionless URLs ---
-  // Two-step: HEAD to get content-type, then partial fetch if needed
+  // Two-step: HEAD to get content-type, then partial fetch if needed.
+  // Returns 'animated', 'static', or 'unknown'. 'unknown' means HEAD failed
+  // or returned a content-type we can't classify (e.g., a Cloudflare
+  // interstitial returning text/html with status 403 before the page passes
+  // verification). Caller should defer the decision in that case.
 
   function detectAnimationForExtensionless(url) {
     return fetch(url, { method: 'HEAD', credentials: 'omit' })
       .then((res) => {
+        if (!res.ok) return 'unknown';
         const ct = (res.headers.get('content-type') || '').toLowerCase();
-        // GIF is always animated
-        if (ct.includes('image/gif')) return true;
-        // Static formats — definitely not animated
+        if (ct.includes('image/gif')) return 'animated';
         if (ct.includes('image/jpeg') || ct.includes('image/svg') ||
-            ct.includes('image/bmp') || ct.includes('image/avif')) return false;
+            ct.includes('image/bmp') || ct.includes('image/avif')) return 'static';
         // WebP/APNG could be either — need to check the bytes
         if (ct.includes('image/webp') || ct.includes('image/png') || ct.includes('image/apng')) {
           return fetch(url, {
@@ -263,12 +266,13 @@
             .then((res2) => res2.arrayBuffer())
             .then((buf) => {
               const bytes = new Uint8Array(buf);
-              return isAnimatedWebPBuffer(bytes) || isAnimatedPNGBuffer(bytes);
-            });
+              return (isAnimatedWebPBuffer(bytes) || isAnimatedPNGBuffer(bytes)) ? 'animated' : 'static';
+            })
+            .catch(() => 'unknown');
         }
-        return false;
+        return 'unknown';
       })
-      .catch(() => false);
+      .catch(() => 'unknown');
   }
 
   // --- Spacer detection ---
@@ -415,12 +419,34 @@
       img.dataset.still = 'probing';
       img.style.visibility = 'hidden';
 
-      detectAnimationForExtensionless(src).then((animated) => {
-        if (animated) {
+      const apply = (result) => {
+        if (result === 'animated') {
           replaceWithPlaceholder(img);
         } else {
+          // 'static' or final 'unknown' — fail open (show image). The retry
+          // path below already handled the recoverable-unknown case.
           img.dataset.still = 'static';
           img.style.visibility = '';
+        }
+      };
+
+      detectAnimationForExtensionless(src).then((result) => {
+        if (result !== 'unknown') {
+          apply(result);
+          return;
+        }
+        // HEAD failed at scan time. Common cause: the page navigated through
+        // Cloudflare's "Just a moment..." interstitial, our scan ran on the
+        // pre-verification document, and the resource was 403'd. Defer the
+        // decision until the image actually loads — by then the resource is
+        // definitely fetchable, and a fresh HEAD will return real headers.
+        const retry = () => detectAnimationForExtensionless(src).then(apply);
+        if (img.complete && img.naturalWidth > 0) {
+          // Image already loaded between HEAD failing and now — retry now.
+          retry();
+        } else {
+          img.addEventListener('load', retry, { once: true });
+          img.addEventListener('error', () => apply('static'), { once: true });
         }
       });
     }

--- a/web-extension/host-rules.json
+++ b/web-extension/host-rules.json
@@ -1,0 +1,5 @@
+{
+  "president.mit.edu": [
+    ".curtain-bar { left: 100% !important; }"
+  ]
+}

--- a/web-extension/main-world-patch.js
+++ b/web-extension/main-world-patch.js
@@ -61,4 +61,40 @@
     }
     return origSetAttributeNS.apply(this, arguments);
   };
+
+  // --- jQuery animation disable ---
+  // jQuery's .animate / .fadeIn / .slideUp etc use requestAnimationFrame and
+  // write inline style per frame — invisible to our CSS transition override
+  // and the WAAPI cancellation pass (they're not Animation objects). Pages
+  // like president.mit.edu's hero "curtain-bars" sweep 6 colored bars across
+  // the viewport via `$(el).delay(N).animate({left:'98%'}, 500–700)` — a
+  // migraine-grade flourish that the rest of our pipeline misses.
+  //
+  // jQuery ships a global kill-switch: `jQuery.fx.off = true` completes every
+  // animation synchronously on the next tick, skipping straight to the end
+  // state. We intercept `window.jQuery` and `window.$` via defineProperty so
+  // the flag is flipped the instant the page assigns either one. Zepto uses
+  // the same `fx.off` convention so this patch covers it too.
+  function patchAnimatedLibrary(v) {
+    // jQuery's `.fx` is `Tween.prototype.init`, which is a function (with
+    // .step, .speeds, .tick, .off attached). Zepto's `.fx` is also a function
+    // (constructor). Check for function OR object — excluding only null/prim.
+    if (v && v.fx && (typeof v.fx === 'object' || typeof v.fx === 'function')) {
+      try { v.fx.off = true; } catch (e) { /* frozen / sealed fx */ }
+    }
+    return v;
+  }
+  function defineJQueryGlobal(name) {
+    let slot = window[name];
+    if (slot) patchAnimatedLibrary(slot);
+    try {
+      Object.defineProperty(window, name, {
+        configurable: true,
+        get: function () { return slot; },
+        set: function (val) { slot = patchAnimatedLibrary(val); },
+      });
+    } catch (e) { /* existing non-configurable property; best-effort only */ }
+  }
+  defineJQueryGlobal('jQuery');
+  defineJQueryGlobal('$');
 })();

--- a/web-extension/manifest.json
+++ b/web-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Still",
-  "version": "1.2",
+  "version": "1.3",
   "description": "Block animated GIFs, WebP, and APNG. Pause autoplay video. Cancel CSS animations.",
   "permissions": [
     "activeTab",

--- a/web-extension/manifest.json
+++ b/web-extension/manifest.json
@@ -63,7 +63,7 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["icons/frozen.svg"],
+      "resources": ["icons/frozen.svg", "host-rules.json"],
       "matches": ["<all_urls>"]
     }
   ]


### PR DESCRIPTION
Five sites' worth of investigation rolled into a focused branch. Highlights:

## Extension fixes

- **`Recover from HEAD failure during page bot-wall (axios.com)`** — Path E (extensionless URL → HEAD content-type sniff) was treating "HEAD returned 403/text-html" the same as "HEAD returned image/jpeg" → marked the image static and never retried. Sites behind Cloudflare's "Just a moment..." interstitial would have their post-verification animated GIFs leak through. Now distinguishes `unknown` from `static` and retries on the `load` event when HEAD couldn't classify. Repro on axios.com homepage thumbnails (Next.js `/_next/image?url=...gif&w=1920&q=75` proxy URLs).

- **`Add per-host CSS rule pack; defuse MIT OP curtain-bars hero flourish`** — president.mit.edu's hero runs a jQuery `.animate({left:'98%'}, 700)` sweep across 6 colored bars on page load. jQuery is webpack-bundled inside vendors.js so the global `window.jQuery.fx.off=true` patch can't reach it. Adds a curated `host-rules.json` (host → CSS-rule list) loaded at init by content.js and applied as an `!important` stylesheet that beats inline-style writes. Verified: `meanMotion 0.090 → 0.011`, `5.6% moving frames → 0.4%` (better than the bare site, since baseline still has the curtain animation playing). New site rules are now a one-line edit.

- **`Defuse global-jQuery .animate via main-world fx.off intercept`** — `main-world-patch.js` intercepts `window.jQuery` / `window.$` assignment and flips `fx.off=true`. Helps any site that exposes jQuery globally (Drupal/WordPress/older). Doesn't reach webpack-bundled jQuery — that's what the rule pack covers.

## Harness improvements

- **`Motion harness: probe load-time animations, fix YAVG parser, system-Chrome flag`** —
  - `probe.mts` gets `--include-load` (skip the post-hydration mutation-clock reset, so on-load flourishes are visible) and dumps each early WAAPI animation's keyframes / duration / target outerHTML.
  - `analyze.mts` YAVG regex was `[\d.]+` and silently truncated scientific-notation exponents — values like `7.71484e-05` (numerically zero) were read as `7.7`, faking huge motion spikes on near-identical frames. Now `[-+eE\d.]+`.
  - `capture-display.mts` gets `--system-chrome` to launch via the system Chrome stable binary (real TLS fingerprint).

## iOS build

- **`Sync web-extension/ changes into Safari iOS project resources`** — file copies into `Still/Still/Still Extension/Resources/`.
- **`Wire main-world-patch.js and host-rules.json into iOS Xcode project`** — both files were on disk in `Resources/` but unreferenced in `project.pbxproj`'s PBXFileReference / PBXBuildFile / PBXGroup / PBXResourcesBuildPhase, so iOS builds were silently excluding them from the .appex bundle. `main-world-patch.js` had been missing since its sync in 6bed9ae (so the SVG-geometry-settle fix never actually shipped to iOS Safari). Now both are wired in. Validated with `xcodebuild -showBuildSettings` and `plutil -lint`.

## Test plan

- [x] `npx playwright test freeze.spec.js` — 29/29 pass, including 3 new regression tests
- [x] Virtual-display capture confirms MIT OP curtain bars no longer animate (single initial-paint frame at t=0.4s, then `0%` moving frames)
- [x] axios cf-race regression test reproduces the 403→200 sequence and confirms image gets `data-still="replaced"`
- [x] `xcodebuild -project Still/Still/Still.xcodeproj -target "Still Extension" -showBuildSettings` exits 0
- [x] `plutil -lint` on `project.pbxproj` returns OK
- [ ] Manual verification of axios.com fix on the next animated thumbnail to rotate onto the homepage (the article we found mid-session has already rotated off)
- [ ] Full iOS .appex rebuild + on-device check that `host-rules.json` and `main-world-patch.js` are in the bundle and the MIT OP rule applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)