### PR TITLE
Block Google Shopping AR-spin video previews

### DIFF
--- a/Still/Still/Still Extension/Resources/content.js
+++ b/Still/Still/Still Extension/Resources/content.js
@@ -61,6 +61,15 @@
     '  visibility: visible !important;',
     "  background: #e8e8e8 url(\"" + PLACEHOLDER + "\") center/contain no-repeat !important;",
     '  object-position: -9999px -9999px !important;',
+    '}',
+    // Inline video previews used as image substitutes (Google Shopping AR
+    // spin previews, e.g. `gstatic.com/search-ar-dev/...`) — hide once we've
+    // tagged them. visibility:hidden preserves layout so the sibling poster
+    // <img> in the same card stays in its slot. Pairs with blockVideoPreview()
+    // which pauses and neuters .play() so JS-driven hover/intersection
+    // handlers can't restart playback.
+    'video[data-still-video="blocked"] {',
+    '  visibility: hidden !important;',
     '}'
   ].join('\n');
   (document.head || document.documentElement).appendChild(style);
@@ -560,11 +569,48 @@
     });
   }
 
-  // --- Pause all videos ---
+  // --- Pause all videos + neuter image-substitute video previews ---
+
+  // URL patterns for inline videos used as animated-image substitutes —
+  // muted, playsinline, aria-hidden previews that ordinary autoplay blockers
+  // (Safari's built-in, StopTheMadness Pro) let through because there's no
+  // `autoplay` attribute and `muted+playsinline` is exempt under spec.
+  // First entry: Google Shopping's AR product spin previews on the SERP.
+  const VIDEO_PREVIEW_BLOCKLIST_RE = /\/\/[^/]*\.gstatic\.com\/search-ar-dev\//i;
+
+  function videoSrcs(v) {
+    const out = [];
+    if (v.currentSrc) out.push(v.currentSrc);
+    if (v.src) out.push(v.src);
+    v.querySelectorAll('source').forEach((s) => { if (s.src) out.push(s.src); });
+    return out;
+  }
+
+  function isVideoPreviewToBlock(v) {
+    return videoSrcs(v).some((s) => VIDEO_PREVIEW_BLOCKLIST_RE.test(s));
+  }
+
+  function blockVideoPreview(v) {
+    if (v.dataset.stillVideo === 'blocked') return;
+    v.dataset.stillVideo = 'blocked';
+    try { v.pause(); } catch (e) {}
+    try { v.removeAttribute('autoplay'); } catch (e) {}
+    // Override .play() on this specific element so JS-triggered playback
+    // (Google's IntersectionObserver / hover handlers) becomes a no-op.
+    // We resolve the returned Promise to keep callers from throwing.
+    try {
+      Object.defineProperty(v, 'play', {
+        value: function () { return Promise.resolve(); },
+        writable: false,
+        configurable: false,
+      });
+    } catch (e) {}
+  }
 
   function pauseVideos() {
     document.querySelectorAll('video').forEach((v) => {
       try { v.pause(); } catch (e) {}
+      if (isVideoPreviewToBlock(v)) blockVideoPreview(v);
     });
   }
 
@@ -606,9 +652,13 @@
                 processImage(node);
               } else if (node.tagName === 'VIDEO') {
                 try { node.pause(); } catch (e) {}
+                if (isVideoPreviewToBlock(node)) blockVideoPreview(node);
               } else if (node.querySelectorAll) {
                 node.querySelectorAll('img').forEach(processImage);
-                node.querySelectorAll('video').forEach((v) => { try { v.pause(); } catch (e) {} });
+                node.querySelectorAll('video').forEach((v) => {
+                  try { v.pause(); } catch (e) {}
+                  if (isVideoPreviewToBlock(v)) blockVideoPreview(v);
+                });
                 // Check for SVG animations in added subtree
                 if (node.tagName === 'SVG' || node.querySelector?.('svg, animate, animateTransform, animateMotion, set')) {
                   killSVGAnimations();
@@ -645,6 +695,16 @@
               target.removeAttribute('srcset');
               target.removeAttribute('src');
             }
+          }
+          // Late-bound video src — Google sometimes inserts <video> first then
+          // assigns src as the carousel scrolls into view. Re-check on src
+          // change so we still catch the AR-shopping pattern.
+          if (target.tagName === 'VIDEO' && target.dataset.stillVideo !== 'blocked') {
+            if (isVideoPreviewToBlock(target)) blockVideoPreview(target);
+          }
+          if (target.tagName === 'SOURCE' && target.parentElement?.tagName === 'VIDEO') {
+            const v = target.parentElement;
+            if (v.dataset.stillVideo !== 'blocked' && isVideoPreviewToBlock(v)) blockVideoPreview(v);
           }
         }
       }
@@ -749,6 +809,7 @@
       isSpacer, isAnimatedDataGif,
       scanAll, scanBackgroundImages, killSVGAnimations, flaggedAnimatedURLs,
       cancelAnimations,
+      isVideoPreviewToBlock, blockVideoPreview, pauseVideos,
     };
   }
 

--- a/Still/Still/Still Extension/Resources/content.js
+++ b/Still/Still/Still Extension/Resources/content.js
@@ -63,13 +63,16 @@
     '  object-position: -9999px -9999px !important;',
     '}',
     // Inline video previews used as image substitutes (Google Shopping AR
-    // spin previews, e.g. `gstatic.com/search-ar-dev/...`) — hide once we've
-    // tagged them. visibility:hidden preserves layout so the sibling poster
-    // <img> in the same card stays in its slot. Pairs with blockVideoPreview()
-    // which pauses and neuters .play() so JS-driven hover/intersection
-    // handlers can't restart playback.
+    // spin previews, e.g. `gstatic.com/search-ar-dev/...`). display:none
+    // (not visibility:hidden) — Google's product cards position the video
+    // absolutely over the static poster <img>, so removing it from layout
+    // doesn't shift anything. visibility:hidden was leaking visible motion
+    // (user report 2026-05-09) — likely because the video element kept a
+    // composited layer that decoded frames even while "invisible". Pairs
+    // with blockVideoPreview() which pauses and neuters .play() so JS-
+    // driven hover/intersection handlers can't restart playback.
     'video[data-still-video="blocked"] {',
-    '  visibility: hidden !important;',
+    '  display: none !important;',
     '}'
   ].join('\n');
   (document.head || document.documentElement).appendChild(style);

--- a/Still/Still/Still Extension/Resources/main-world-patch.js
+++ b/Still/Still/Still Extension/Resources/main-world-patch.js
@@ -19,6 +19,17 @@
  * elements with that attribute.
  */
 (function () {
+  // Marker so we can tell from outside whether this main-world script
+  // ever ran on a page. Useful when diagnosing CSP / world:MAIN drops on
+  // sites with strict CSPs (Google's `require-trusted-types-for 'script'`
+  // is the canonical case) — without this marker the only way to tell is
+  // observing prototype.play.toString() at runtime, which is racy.
+  try {
+    if (document && document.documentElement) {
+      document.documentElement.setAttribute('data-still-mwp', 'loaded');
+    }
+  } catch (e) {}
+
   const SETTLE_MS = 300;
   const svgSettleTimers = new WeakMap();
   const origSetAttribute = Element.prototype.setAttribute;

--- a/Still/Still/Still Extension/Resources/main-world-patch.js
+++ b/Still/Still/Still Extension/Resources/main-world-patch.js
@@ -98,20 +98,49 @@
   defineJQueryGlobal('jQuery');
   defineJQueryGlobal('$');
 
-  // --- HTMLMediaElement.play() interception for tagged image-substitute videos ---
+  // --- HTMLMediaElement.play() interception for image-substitute videos ---
   // Inline <video> previews used as animated-GIF substitutes (Google Shopping
   // AR spin previews on the SERP, etc.) bypass autoplay blockers because they
   // ship with `muted+playsinline` (spec-exempt) and no `autoplay` attribute —
-  // the page calls `.play()` from an IntersectionObserver/hover handler. Our
-  // content script (isolated world) tags those elements with
-  // `data-still-video="blocked"`, but its property override on `play` doesn't
-  // apply when page script calls `play()` from this main world. So we patch
-  // the prototype here, gated by the data attribute (which IS shared across
-  // worlds because it's a real DOM attribute).
+  // the page calls `.play()` from an IntersectionObserver/hover handler.
+  //
+  // We catch them two ways here, both synchronous to the .play() call so
+  // there's no window in which a video can slip through:
+  //   1. data-still-video="blocked" attribute (set by content.js when it
+  //      walks the DOM; also set by us below when we match by URL).
+  //   2. URL pattern check on src / currentSrc / <source> children. This is
+  //      the race-safe path: Google inserts a video card and calls .play()
+  //      in the SAME tick, before content.js's MutationObserver fires. If we
+  //      gated only on the tag, the first .play() call would slip through
+  //      (user reported: "after I scrolled down and started hovering, later
+  //      stuff started playing"). The URL check runs before content.js has
+  //      to do anything.
+  const VIDEO_PREVIEW_BLOCKLIST_RE = /\/\/[^/]*\.gstatic\.com\/search-ar-dev\//i;
+  function srcMatchesBlocklist(v) {
+    const csrc = v.currentSrc;
+    if (csrc && VIDEO_PREVIEW_BLOCKLIST_RE.test(csrc)) return true;
+    const src = v.getAttribute && v.getAttribute('src');
+    if (src && VIDEO_PREVIEW_BLOCKLIST_RE.test(src)) return true;
+    if (v.querySelectorAll) {
+      const sources = v.querySelectorAll('source');
+      for (let i = 0; i < sources.length; i++) {
+        const ss = sources[i].getAttribute && sources[i].getAttribute('src');
+        if (ss && VIDEO_PREVIEW_BLOCKLIST_RE.test(ss)) return true;
+      }
+    }
+    return false;
+  }
   const origMediaPlay = HTMLMediaElement.prototype.play;
   HTMLMediaElement.prototype.play = function () {
-    if (this.getAttribute && this.getAttribute('data-still-video') === 'blocked') {
+    const tagged = this.getAttribute && this.getAttribute('data-still-video') === 'blocked';
+    if (tagged || srcMatchesBlocklist(this)) {
       try { this.pause(); } catch (e) {}
+      // Tag the element so the CSS hide rule + MutationObserver re-checks
+      // also see it. setAttribute writes a real DOM attribute that's visible
+      // to the isolated-world content script too.
+      try {
+        if (!tagged && this.setAttribute) this.setAttribute('data-still-video', 'blocked');
+      } catch (e) {}
       return Promise.resolve();
     }
     return origMediaPlay.apply(this, arguments);

--- a/Still/Still/Still Extension/Resources/main-world-patch.js
+++ b/Still/Still/Still Extension/Resources/main-world-patch.js
@@ -97,4 +97,23 @@
   }
   defineJQueryGlobal('jQuery');
   defineJQueryGlobal('$');
+
+  // --- HTMLMediaElement.play() interception for tagged image-substitute videos ---
+  // Inline <video> previews used as animated-GIF substitutes (Google Shopping
+  // AR spin previews on the SERP, etc.) bypass autoplay blockers because they
+  // ship with `muted+playsinline` (spec-exempt) and no `autoplay` attribute —
+  // the page calls `.play()` from an IntersectionObserver/hover handler. Our
+  // content script (isolated world) tags those elements with
+  // `data-still-video="blocked"`, but its property override on `play` doesn't
+  // apply when page script calls `play()` from this main world. So we patch
+  // the prototype here, gated by the data attribute (which IS shared across
+  // worlds because it's a real DOM attribute).
+  const origMediaPlay = HTMLMediaElement.prototype.play;
+  HTMLMediaElement.prototype.play = function () {
+    if (this.getAttribute && this.getAttribute('data-still-video') === 'blocked') {
+      try { this.pause(); } catch (e) {}
+      return Promise.resolve();
+    }
+    return origMediaPlay.apply(this, arguments);
+  };
 })();

--- a/Still/Still/Still Extension/Resources/manifest.json
+++ b/Still/Still/Still Extension/Resources/manifest.json
@@ -27,6 +27,11 @@
         "id": "ruleset_apng",
         "enabled": false,
         "path": "rules/ruleset_apng.json"
+      },
+      {
+        "id": "ruleset_ar_video",
+        "enabled": true,
+        "path": "rules/ruleset_ar_video.json"
       }
     ]
   },

--- a/Still/Still/Still Extension/Resources/manifest.json
+++ b/Still/Still/Still Extension/Resources/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Still",
-  "version": "1.3",
+  "version": "1.4",
   "description": "Block animated GIFs, WebP, and APNG. Pause autoplay video. Cancel CSS animations.",
   "permissions": [
     "activeTab",

--- a/Still/Still/Still Extension/Resources/rules/ruleset_ar_video.json
+++ b/Still/Still/Still Extension/Resources/rules/ruleset_ar_video.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": 1,
+    "priority": 1,
+    "action": { "type": "block" },
+    "condition": {
+      "urlFilter": "||gstatic.com/search-ar-dev/",
+      "resourceTypes": ["media", "image", "xmlhttprequest", "other"]
+    }
+  }
+]

--- a/Still/Still/Still.xcodeproj/project.pbxproj
+++ b/Still/Still/Still.xcodeproj/project.pbxproj
@@ -472,7 +472,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 55XHFQJ4X3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Still Extension/Info.plist";
@@ -484,7 +484,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -505,7 +505,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 55XHFQJ4X3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Still Extension/Info.plist";
@@ -517,7 +517,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -540,7 +540,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 55XHFQJ4X3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Still/Info.plist;
@@ -555,7 +555,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -580,7 +580,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 55XHFQJ4X3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Still/Info.plist;
@@ -595,7 +595,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/tests/freeze.spec.js
+++ b/tests/freeze.spec.js
@@ -1333,4 +1333,90 @@ test.describe('Still — block and replace logic', () => {
     expect(result.okTag).toBeNull();                 // legitimate video untouched
     expect(result.okIntercepted).toBe(false);
   });
+
+  test('blocks lazy-inserted gstatic AR videos that are .play()ed in the same tick (race-safe)', async ({ page }) => {
+    // Race the user reported in real Chrome: initial-viewport videos got
+    // blocked, but "after I scrolled down and started hovering, later stuff
+    // started playing." The pattern: Google's IntersectionObserver / hover
+    // handler fires when a card scrolls into view, inserts a <video> element
+    // and synchronously calls .play() on it in the same JS tick — BEFORE
+    // content.js's MutationObserver fires to walk the new node and tag it.
+    //
+    // The earlier defense gated the .play() interception on
+    // data-still-video="blocked" being already present. With the tag absent
+    // (because we beat content.js), play() slipped through and the video ran.
+    // The fix: main-world-patch.js's HTMLMediaElement.prototype.play override
+    // ALSO checks the element's src URL against VIDEO_PREVIEW_BLOCKLIST_RE,
+    // synchronously inside the play() call. Tag-or-URL gate, no race.
+    //
+    // This test reproduces the timing exactly: insert a video and call play()
+    // in one synchronous block, then assert paused.
+    const fs = require('fs');
+    const mainWorldPatch = fs.readFileSync(MAIN_WORLD_PATCH, 'utf8');
+    await page.setContent(`
+      <!DOCTYPE html>
+      <script>${mainWorldPatch}</script>
+      <body></body>
+    `);
+    const result = await page.evaluate(async () => {
+      // Synchronous insert + immediate play(), no awaiting MutationObserver.
+      const v = document.createElement('video');
+      v.muted = true; v.playsInline = true;
+      // Note: src attribute set BEFORE insert so currentSrc/src are populated
+      // when play() is called. Mirrors what real Google does.
+      v.src = 'https://www.gstatic.com/search-ar-dev/renders/foo/square_video.mp4';
+      document.body.appendChild(v);
+      const playResult = await v.play().then(() => 'resolved').catch((e) => 'rejected:' + e.name);
+      // Also test the <source>-children path: same race, source child instead
+      // of attribute. (Some carousels use this form.)
+      const v2 = document.createElement('video');
+      v2.muted = true; v2.playsInline = true;
+      const s = document.createElement('source');
+      s.src = 'https://www.gstatic.com/search-ar-dev/renders/bar/square_video.mp4';
+      v2.appendChild(s);
+      document.body.appendChild(v2);
+      const playResult2 = await v2.play().then(() => 'resolved').catch((e) => 'rejected:' + e.name);
+      // Control: a video with a non-blocklisted src must NOT be intercepted.
+      // (Don't actually load anything — empty src is fine; the patch should
+      // forward to the original play() and let it reject naturally.)
+      const v3 = document.createElement('video');
+      v3.muted = true; v3.playsInline = true;
+      v3.src = 'data:video/mp4;base64,aaaa';
+      document.body.appendChild(v3);
+      let v3Intercepted;
+      try {
+        await v3.play();
+        // If we got here, play() didn't reject — the patch let it through to
+        // origMediaPlay. Whatever happens next (NotSupportedError eventually)
+        // is real-browser behavior, not interception.
+        v3Intercepted = false;
+      } catch (e) {
+        // play() rejected — that's the unpatched path firing on bad data.
+        // Importantly NOT NotAllowedError-from-our-Promise.resolve route.
+        v3Intercepted = false;
+      }
+      // Drain pending tasks so paused state stabilizes.
+      await new Promise((r) => setTimeout(r, 50));
+      return {
+        v_paused: v.paused,
+        v_playResult: playResult,
+        v_taggedAfter: v.getAttribute('data-still-video'),
+        v2_paused: v2.paused,
+        v2_playResult: playResult2,
+        v2_taggedAfter: v2.getAttribute('data-still-video'),
+        v3_intercepted: v3Intercepted,
+        v3_taggedAfter: v3.getAttribute('data-still-video'),
+      };
+    });
+    // src-attribute path
+    expect(result.v_playResult).toBe('resolved');
+    expect(result.v_paused).toBe(true);
+    expect(result.v_taggedAfter).toBe('blocked');
+    // <source>-children path
+    expect(result.v2_playResult).toBe('resolved');
+    expect(result.v2_paused).toBe(true);
+    expect(result.v2_taggedAfter).toBe('blocked');
+    // Control: unrelated video not tagged
+    expect(result.v3_taggedAfter).toBeNull();
+  });
 });

--- a/tests/freeze.spec.js
+++ b/tests/freeze.spec.js
@@ -5,6 +5,7 @@ const http = require('http');
 const fs = require('fs');
 
 const CONTENT_SCRIPT = path.resolve(__dirname, '..', 'web-extension', 'content.js');
+const MAIN_WORLD_PATCH = path.resolve(__dirname, '..', 'web-extension', 'main-world-patch.js');
 const TESTS_DIR = path.resolve(__dirname);
 
 let server;
@@ -1258,5 +1259,78 @@ test.describe('Still — block and replace logic', () => {
     // Fill should be upgraded from 'none' to 'forwards' so the end state
     // persists after currentTime == duration.
     expect(result.noneFill).toBe('forwards');
+  });
+
+  test('blocks gstatic search-ar-dev video previews and intercepts programmatic .play()', async ({ page }) => {
+    // Google Shopping serves auto-spinning product previews as small muted
+    // playsinline <video> elements pointed at gstatic.com/search-ar-dev/...
+    // mp4. They bypass autoplay blockers (no `autoplay` attribute, muted +
+    // playsinline are spec-exempt) by calling videoEl.play() from an
+    // IntersectionObserver/hover handler. Our defense:
+    //   1. content.js tags matching elements with data-still-video="blocked"
+    //      and pauses them.
+    //   2. main-world-patch.js patches HTMLMediaElement.prototype.play so
+    //      that calling .play() on a tagged element is a no-op (returns a
+    //      resolved Promise without starting playback).
+    // Both are required: the prototype patch must live in the main world
+    // (where page scripts call play), and the tag must live on the DOM
+    // attribute (which IS shared across worlds).
+    const fs = require('fs');
+    const contentJs = fs.readFileSync(CONTENT_SCRIPT, 'utf8');
+    const mainWorldPatch = fs.readFileSync(MAIN_WORLD_PATCH, 'utf8');
+    await page.setContent(`
+      <!DOCTYPE html>
+      <script>
+        window.browser = {
+          storage: { local: {
+            get(keys, cb) { cb({ enabled: true, allowlist: [] }); },
+            set() {},
+          }},
+          runtime: { onMessage: { addListener() {} }, sendMessage() { return Promise.resolve(); } },
+        };
+      </script>
+      <script>${mainWorldPatch}</script>
+      <script>${contentJs}</script>
+      <body>
+        <video id="ar"   muted playsinline preload="none"
+               src="https://www.gstatic.com/search-ar-dev/renders/abc/square_video.mp4"></video>
+        <video id="ok"   muted playsinline preload="none"
+               src="https://example.com/legitimate.mp4"></video>
+      </body>
+    `);
+    await page.waitForFunction(() => !!window.__still, { timeout: 3000 });
+
+    // Give the initial scan a tick to tag the matching video.
+    await page.waitForFunction(
+      () => document.getElementById('ar').dataset.stillVideo === 'blocked',
+      { timeout: 3000 }
+    );
+
+    const result = await page.evaluate(async () => {
+      const ar = document.getElementById('ar');
+      const ok = document.getElementById('ok');
+      // Tag check + .play() interception check.
+      const arPlayResult = await ar.play().then(() => 'resolved').catch((e) => 'rejected:' + e.name);
+      // For the unrelated video we don't actually want it to start playing in
+      // the test (would be flaky with no-src loading) — what we care about is
+      // that the prototype patch DIDN'T short-circuit it. We verify by
+      // checking the function identity: ar's .play returns Promise.resolve()
+      // immediately; ok's .play would attempt to load the src.
+      const okIntercepted = ok.dataset.stillVideo === 'blocked';
+      // Cancel ok's load attempt cleanly to avoid test-runtime warnings.
+      try { ok.removeAttribute('src'); ok.load(); } catch (e) {}
+      return {
+        arTag: ar.dataset.stillVideo,
+        arPaused: ar.paused,
+        arPlayResult,
+        okTag: ok.dataset.stillVideo || null,
+        okIntercepted,
+      };
+    });
+    expect(result.arTag).toBe('blocked');
+    expect(result.arPaused).toBe(true);              // never started despite play()
+    expect(result.arPlayResult).toBe('resolved');    // play() returns resolved Promise
+    expect(result.okTag).toBeNull();                 // legitimate video untouched
+    expect(result.okIntercepted).toBe(false);
   });
 });

--- a/tests/motion/capture-display.mts
+++ b/tests/motion/capture-display.mts
@@ -61,6 +61,12 @@ const scrollThenSit = process.argv.includes('--scroll-then-sit');
 // axios.com require even with valid cookies. Channel 'chrome' is set up by
 // `npx playwright install chrome`.
 const useSystemChrome = process.argv.includes('--system-chrome');
+// Deterministically trigger Google Shopping-style AR-video previews: after
+// navigation + scroll, call .play() on every <video> on the page. Used to
+// verify that the gstatic.com/search-ar-dev blocker actually prevents
+// playback in real Chrome — without this flag, autoplay is gated on a
+// signed-in/personalized SERP that stealth Chrome doesn't reliably get.
+const forcePlayVideos = process.argv.includes('--force-play-videos');
 
 mkdirSync(outDir, { recursive: true });
 const framesDir = join(outDir, 'frames');
@@ -161,6 +167,25 @@ if (scrollThenSit) {
     }
     // Remaining time of the capture window: just sit.
   })().catch((e) => console.error('scroll workload error:', (e as Error).message));
+}
+
+if (forcePlayVideos) {
+  (async () => {
+    // Wait for ffmpeg to settle and (if scrolling) for the scroll loop to
+    // have moved videos into view. Then call play() on every <video> — this
+    // is what Google's IntersectionObserver does, but we do it deterministically
+    // so the test isn't gated on Google's anti-bot detection deciding to
+    // ship the AR carousel to this session.
+    const settle = scrollThenSit ? 5500 : 1500;
+    await page.waitForTimeout(settle);
+    try {
+      await page.evaluate(() => {
+        for (const v of Array.from(document.querySelectorAll('video'))) {
+          try { v.play(); } catch (e) {}
+        }
+      });
+    } catch (e) {}
+  })().catch((e) => console.error('force-play-videos error:', (e as Error).message));
 }
 
 await done;

--- a/tests/motion/diagnose.mts
+++ b/tests/motion/diagnose.mts
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+// Forensic image diagnostic. Headless Playwright + stealth + Still extension +
+// optional cookies. Loads a URL, lets the extension run, then enumerates every
+// <img>, <picture>/<source>, iframe, and CSS background-image, plus magic-byte
+// sniffs each unique image URL to confirm content type and animation status.
+//
+// Output: a single JSON report to stdout (and --out <file> if given).
+//
+// Usage:
+//   npx tsx tests/motion/diagnose.mts \
+//     --url 'https://www.google.com/search?q=dish+drain+rack' \
+//     --cookies tests/motion/cookies/google.com.json \
+//     --ext web-extension \
+//     --seconds 8 \
+//     --out tests/motion/reports/diag-dish-drain.json
+
+import { chromium as rawChromium, type Cookie } from '@playwright/test';
+import { addExtra } from 'playwright-extra';
+import StealthPlugin from 'puppeteer-extra-plugin-stealth';
+import { mkdirSync, existsSync, writeFileSync, readFileSync, mkdtempSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const chromium = addExtra(rawChromium);
+chromium.use(StealthPlugin());
+
+function arg(name: string): string | undefined;
+function arg(name: string, fallback: string): string;
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : fallback;
+}
+
+const url = arg('url');
+if (!url) { console.error('--url required'); process.exit(1); }
+const cookiesFile = arg('cookies');
+const extDir = arg('ext') ? resolve(arg('ext')!) : null;
+const seconds = parseInt(arg('seconds', '8'), 10);
+const outFile = arg('out');
+
+const userDataDir = mkdtempSync(join(tmpdir(), 'still-diag-'));
+const launchArgs = [
+  '--headless=new',
+  '--disable-gpu',
+  '--hide-scrollbars',
+  '--mute-audio',
+];
+if (extDir) {
+  launchArgs.push(`--disable-extensions-except=${extDir}`);
+  launchArgs.push(`--load-extension=${extDir}`);
+}
+
+const context = await chromium.launchPersistentContext(userDataDir, {
+  headless: false,
+  args: launchArgs,
+  viewport: { width: 1280, height: 1600 },
+});
+
+if (cookiesFile && existsSync(cookiesFile)) {
+  const cookies: Cookie[] = JSON.parse(readFileSync(cookiesFile, 'utf8'));
+  for (const c of cookies) {
+    if (c.sameSite === 'None' && !c.secure) c.sameSite = 'Lax';
+    try { await context.addCookies([c]); } catch {}
+  }
+}
+
+const page = await context.newPage();
+if (extDir) await page.waitForTimeout(1500);
+
+// Capture console messages — we may instrument content.js with debug logs.
+const consoleLog: { type: string; text: string }[] = [];
+page.on('console', (m) => { consoleLog.push({ type: m.type(), text: m.text() }); });
+page.on('pageerror', (err) => { consoleLog.push({ type: 'pageerror', text: err.message }); });
+
+// Track every image-ish network response so we can correlate URL → content-type → bytes.
+type NetEntry = { url: string; status: number; contentType: string | null; size: number; magic: string | null; resourceType: string };
+const netByUrl = new Map<string, NetEntry>();
+page.on('response', async (resp) => {
+  try {
+    const u = resp.url();
+    const rt = resp.request().resourceType();
+    if (rt !== 'image' && rt !== 'media' && !/\.(gif|webp|apng|png|jpe?g|avif)(\?|$)/i.test(u)) return;
+    const ct = resp.headers()['content-type'] || null;
+    let body: Buffer | null = null;
+    try { body = await resp.body(); } catch {}
+    const size = body ? body.length : 0;
+    let magic: string | null = null;
+    if (body && body.length >= 12) {
+      const b = body.subarray(0, 16);
+      if (b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46) magic = 'gif';
+      else if (b.toString('ascii', 0, 4) === 'RIFF' && b.toString('ascii', 8, 12) === 'WEBP') {
+        // Sniff for ANIM chunk anywhere in first 4KB.
+        const probe = body.subarray(0, Math.min(body.length, 4096)).toString('binary');
+        magic = probe.includes('ANIM') ? 'webp-animated' : 'webp-static';
+      } else if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) {
+        const probe = body.subarray(0, Math.min(body.length, 4096)).toString('binary');
+        magic = probe.includes('acTL') ? 'apng' : 'png';
+      } else if (b[0] === 0xff && b[1] === 0xd8) magic = 'jpeg';
+      else if (b.toString('ascii', 4, 12).includes('ftypavif') || b.toString('ascii', 4, 12).includes('ftypavis')) magic = 'avif';
+      else magic = 'unknown';
+    }
+    netByUrl.set(u, { url: u, status: resp.status(), contentType: ct, size, magic, resourceType: rt });
+  } catch {}
+});
+
+let navStatus: number | null = null;
+try {
+  const nav = await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45000 });
+  navStatus = nav ? nav.status() : null;
+} catch (e) {
+  console.error('goto failed:', (e as Error).message);
+}
+
+// Wait for body content + extension settle.
+try { await page.waitForFunction(() => (document.body?.innerText || '').length > 200, { timeout: 8000 }); } catch {}
+await page.waitForTimeout(seconds * 1000);
+
+// Enumerate images at the DOM level. We dive into same-origin iframes too.
+// Body fed as a plain-JS string — tsx/esbuild otherwise injects __name
+// helpers (named function tracking) into the compiled evaluate body, and
+// those helpers don't exist in the page context.
+const evalBody = `
+  const collectFromDoc = (doc, iframeSrc) => {
+    const imgs = [];
+    const bgs = [];
+    const iframes = [];
+    const ancestorString = (el) => {
+      const parts = [];
+      let cur = el;
+      let depth = 0;
+      while (cur && depth < 6) {
+        let s = cur.tagName.toLowerCase();
+        if (cur.id) s += '#' + cur.id;
+        if (cur.className && typeof cur.className === 'string') s += '.' + cur.className.toString().split(/\\s+/).filter(Boolean).slice(0, 2).join('.');
+        parts.unshift(s);
+        cur = cur.parentElement;
+        depth++;
+      }
+      return parts.join(' > ');
+    };
+    doc.querySelectorAll('img').forEach((img) => {
+      const r = img.getBoundingClientRect();
+      const cs = doc.defaultView && doc.defaultView.getComputedStyle(img);
+      imgs.push({
+        src: img.src,
+        currentSrc: img.currentSrc,
+        dataStill: img.dataset.still || null,
+        naturalW: img.naturalWidth,
+        naturalH: img.naturalHeight,
+        visibility: cs ? cs.visibility : '',
+        display: cs ? cs.display : '',
+        inViewport: r.top < (doc.defaultView ? doc.defaultView.innerHeight : 0) && r.bottom > 0 && r.width > 0,
+        inIframe: !!iframeSrc,
+        iframeSrc,
+        parentTag: img.parentElement ? img.parentElement.tagName.toLowerCase() : '',
+        ancestorChain: ancestorString(img),
+        role: img.getAttribute('role'),
+        alt: img.getAttribute('alt'),
+      });
+    });
+    doc.querySelectorAll('*').forEach((el) => {
+      const cs = doc.defaultView && doc.defaultView.getComputedStyle(el);
+      const bg = cs && cs.backgroundImage;
+      if (bg && bg !== 'none' && /url\\(/.test(bg)) {
+        const m = bg.match(/url\\(["']?([^)"']+)["']?\\)/);
+        if (m && /^(https?:|data:image)/.test(m[1])) {
+          bgs.push({ url: m[1], selector: ancestorString(el) });
+        }
+      }
+    });
+    doc.querySelectorAll('iframe').forEach((f) => iframes.push(f.src || '(no src)'));
+    return { imgs, bgs, iframes };
+  };
+  const collectVideos = (doc, iframeSrc) => {
+    const videos = [];
+    const ancestorString2 = (el) => {
+      const parts = [];
+      let cur = el;
+      let depth = 0;
+      while (cur && depth < 8) {
+        let s = cur.tagName.toLowerCase();
+        if (cur.id) s += '#' + cur.id;
+        if (cur.className && typeof cur.className === 'string') s += '.' + cur.className.toString().split(/\\s+/).filter(Boolean).slice(0, 3).join('.');
+        parts.unshift(s);
+        cur = cur.parentElement;
+        depth++;
+      }
+      return parts.join(' > ');
+    };
+    doc.querySelectorAll('video').forEach((v) => {
+      const r = v.getBoundingClientRect();
+      const sources = [];
+      v.querySelectorAll('source').forEach((s) => sources.push({ src: s.src, type: s.type }));
+      videos.push({
+        src: v.src || null,
+        currentSrc: v.currentSrc || null,
+        sources,
+        autoplay: v.autoplay,
+        loop: v.loop,
+        muted: v.muted,
+        paused: v.paused,
+        readyState: v.readyState,
+        w: r.width, h: r.height,
+        stillVideo: v.dataset.stillVideo || null,
+        attrs: Array.from(v.attributes).map((a) => a.name + '=' + (a.value || '').slice(0, 40)),
+        ancestorChain: ancestorString2(v),
+        inViewport: r.top < (doc.defaultView ? doc.defaultView.innerHeight : 0) && r.bottom > 0 && r.width > 0,
+        iframeSrc,
+      });
+    });
+    return videos;
+  };
+  const collectAnimations = (doc) => {
+    const out = [];
+    if (!doc.getAnimations) return out;
+    try {
+      doc.getAnimations({ subtree: true }).forEach((a) => {
+        try {
+          const t = a.effect && a.effect.target;
+          let tagDesc = '';
+          if (t) {
+            tagDesc = t.tagName ? t.tagName.toLowerCase() : '';
+            if (t.id) tagDesc += '#' + t.id;
+            if (t.className && typeof t.className === 'string') tagDesc += '.' + t.className.toString().split(/\\s+/).filter(Boolean).slice(0, 2).join('.');
+          }
+          out.push({
+            playState: a.playState,
+            currentTime: a.currentTime,
+            iterationCount: (a.effect && a.effect.getTiming && a.effect.getTiming().iterations) || null,
+            duration: (a.effect && a.effect.getTiming && a.effect.getTiming().duration) || null,
+            target: tagDesc,
+            id: a.id || '',
+          });
+        } catch (e) {}
+      });
+    } catch (e) {}
+    return out;
+  };
+  const top = collectFromDoc(document, null);
+  top.videos = collectVideos(document, null);
+  top.animations = collectAnimations(document);
+  document.querySelectorAll('iframe').forEach((f) => {
+    try {
+      const cd = f.contentDocument;
+      if (cd) {
+        const sub = collectFromDoc(cd, f.src);
+        top.imgs.push.apply(top.imgs, sub.imgs);
+        top.bgs.push.apply(top.bgs, sub.bgs);
+        top.videos.push.apply(top.videos, collectVideos(cd, f.src));
+      }
+    } catch (e) {}
+  });
+  return top;
+`;
+const domReport = await page.evaluate(new Function(evalBody) as any);
+
+// Try programmatically playing every video element. If our blocker is
+// working, the .play() returns a resolved Promise but the video stays
+// paused. This is the authoritative test that bypasses the headless
+// "no autoplay because no user gesture" baseline.
+const playProbe = await page.evaluate(`
+  (async () => {
+    const out = [];
+    for (const v of document.querySelectorAll('video')) {
+      const before = { paused: v.paused, stillVideo: v.dataset.stillVideo || null };
+      let played = null;
+      try {
+        const p = v.play();
+        if (p && p.then) await p.then(() => { played = 'resolved'; }).catch((e) => { played = 'rejected:' + (e && e.name); });
+        else played = 'sync';
+      } catch (e) { played = 'threw:' + (e && e.name); }
+      out.push({
+        src: (v.currentSrc || v.src || '').slice(0, 100),
+        before,
+        after: { paused: v.paused, currentTime: v.currentTime, readyState: v.readyState },
+        played,
+      });
+    }
+    return out;
+  })()
+`);
+
+// Optional: take a screenshot for visual inspection.
+const screenshotPath = outFile ? outFile.replace(/\.json$/, '.png') : null;
+if (screenshotPath) {
+  try { await page.screenshot({ path: screenshotPath, fullPage: true }); } catch {}
+}
+
+const report = {
+  url,
+  finalUrl: page.url(),
+  navStatus,
+  title: await page.title().catch(() => null),
+  bodyLen: await page.evaluate(() => (document.body?.innerText || '').length).catch(() => 0),
+  imageCount: domReport.imgs.length,
+  bgCount: domReport.bgs.length,
+  iframeCount: domReport.iframes.length,
+  iframes: domReport.iframes,
+  videos: domReport.videos || [],
+  playProbe,
+  animations: domReport.animations || [],
+  consoleLog: consoleLog.filter((m) => /still|probe|head|tbn|webp|apng|gif/i.test(m.text)).slice(0, 200),
+  net: Array.from(netByUrl.values()),
+  // Per-image, joined with the network entry where we can match (currentSrc preferred).
+  imgs: domReport.imgs.map((i) => {
+    const ne = netByUrl.get(i.currentSrc) || netByUrl.get(i.src);
+    return { ...i, net: ne || null };
+  }),
+  bgs: domReport.bgs.map((b) => ({ ...b, net: netByUrl.get(b.url) || null })),
+  // Highlight anything that smells animated: gif magic, animated webp, apng.
+  animatedHits: Array.from(netByUrl.values()).filter((e) => e.magic === 'gif' || e.magic === 'webp-animated' || e.magic === 'apng'),
+};
+
+await page.close();
+await context.close();
+
+const json = JSON.stringify(report, null, 2);
+if (outFile) {
+  mkdirSync(dirname(resolve(outFile)), { recursive: true });
+  writeFileSync(outFile, json);
+  console.error(`wrote ${outFile} (${report.imageCount} images, ${report.animatedHits.length} animated)`);
+} else {
+  console.log(json);
+}

--- a/tests/motion/fixture/ar-shopping-mock.html
+++ b/tests/motion/fixture/ar-shopping-mock.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Still motion-test fixture: gstatic AR shopping spin previews</title>
+<style>
+  body { margin: 0; padding: 24px; background: #1a1a1a; color: #eee;
+         font: 14px/1.4 -apple-system, system-ui, sans-serif; }
+  h1   { margin: 0 0 12px; font-size: 18px; font-weight: 500; }
+  p    { margin: 0 0 18px; color: #aaa; }
+  .grid { display: grid; grid-template-columns: repeat(4, 159px);
+          gap: 16px; }
+  .card { background: #2a2a2a; padding: 8px; border-radius: 4px; }
+  /* These attributes match the Google Shopping AR-spin pattern verbatim:
+     muted+playsinline+aria-hidden+disableremoteplayback+preload=none, NO
+     `autoplay` attribute. Trigger script below calls .play() on each one,
+     simulating Google's IntersectionObserver/hover handler. */
+  video { width: 159px; height: 199px; background: #444; display: block; }
+  .label { font-size: 11px; color: #888; margin-top: 4px;
+           white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+</style>
+</head>
+<body>
+<h1>Mock Google Shopping AR-spin carousel</h1>
+<p>Fixture for the Still extension. The four videos below are the real
+mp4s that Google embeds in Shopping carousels (paths captured from prior
+diagnostic runs against live SERPs). Each &lt;video&gt; has the exact attribute
+set Google ships (no <code>autoplay</code> attribute, but
+<code>muted</code>+<code>playsinline</code>+<code>aria-hidden</code>+
+<code>disableremoteplayback</code>+<code>preload="none"</code>). The script
+below calls <code>play()</code> on every video after a 1.5 s delay,
+simulating the IntersectionObserver/hover trigger that ordinary autoplay
+blockers can't catch.</p>
+
+<div class="grid">
+  <div class="card">
+    <video id="v1" muted playsinline aria-hidden="true" disableremoteplayback preload="none"
+           src="https://www.gstatic.com/search-ar-dev/renders/7288397677794265388_ml/7834519064935726986_v5/square_video.mp4"></video>
+    <div class="label">v1 (square_video)</div>
+  </div>
+  <div class="card">
+    <video id="v2" muted playsinline aria-hidden="true" disableremoteplayback preload="none"
+           src="https://www.gstatic.com/search-ar-dev/renders/14970581154744047088_ml/9792256154545184134_v5/square_video.mp4"></video>
+    <div class="label">v2 (square_video)</div>
+  </div>
+  <div class="card">
+    <video id="v3" muted playsinline aria-hidden="true" disableremoteplayback preload="none"
+           src="https://www.gstatic.com/search-ar-dev/renders/9680629773273341113_ml/9831554337451611906_v5/square_video.mp4"></video>
+    <div class="label">v3 (square_video)</div>
+  </div>
+  <div class="card">
+    <video id="v4" muted playsinline aria-hidden="true" disableremoteplayback preload="none"
+           src="https://www.gstatic.com/search-ar-dev/renders/69f3e6342f0272c8/spin_square.mp4"></video>
+    <div class="label">v4 (spin_square)</div>
+  </div>
+</div>
+
+<script>
+  // Simulate Google's IntersectionObserver / hover-driven trigger.
+  // Loop forever — each video, when it ends, restart it. This makes motion
+  // continuous over the entire capture window so meanMotion is meaningful.
+  setTimeout(() => {
+    for (const v of document.querySelectorAll('video')) {
+      v.addEventListener('ended', () => v.play().catch(() => {}));
+      v.play().catch(() => {});
+    }
+  }, 1500);
+</script>
+</body>
+</html>

--- a/tests/motion/headed-record.mts
+++ b/tests/motion/headed-record.mts
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Headed Chromium + Playwright recordVideo. Used when:
+//  - Headless suppresses media playback (AR-spin <video> elements stay
+//    blank even with muted+playsinline), AND
+//  - AVFoundation screen capture isn't available (TCC screen-recording
+//    permission revoked).
+//
+// Chrome runs headed at the given virtual-display coords, but recordVideo
+// pulls the renderer's output via CDP so frames arrive regardless of where
+// the OS draws the window. Output: recording.webm in --out, compatible
+// with analyze.mts.
+
+import { chromium as rawChromium } from '@playwright/test';
+import { addExtra } from 'playwright-extra';
+import StealthPlugin from 'puppeteer-extra-plugin-stealth';
+import { mkdirSync, readdirSync, renameSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const chromium = addExtra(rawChromium);
+chromium.use(StealthPlugin());
+
+function arg(name: string): string | undefined;
+function arg(name: string, fallback: string): string;
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : fallback;
+}
+const url = arg('url');
+const outArg = arg('out');
+const extArg = arg('ext');
+const winX = arg('window-x', '-2540');
+const winY = arg('window-y', '-220');
+const seconds = parseInt(arg('seconds', '15'), 10);
+const windowW = parseInt(arg('window-w', '1280'), 10);
+const windowH = parseInt(arg('window-h', '800'), 10);
+if (!url || !outArg) { console.error('--url --out required'); process.exit(1); }
+const outDir = resolve(outArg);
+mkdirSync(outDir, { recursive: true });
+const extDir = extArg ? resolve(extArg) : null;
+
+const launchArgs = [
+  `--window-position=${winX},${winY}`,
+  `--window-size=${windowW},${windowH}`,
+  '--mute-audio',
+  '--hide-scrollbars',
+  '--disable-blink-features=AutomationControlled',
+  '--autoplay-policy=no-user-gesture-required',
+];
+if (extDir) launchArgs.push(`--disable-extensions-except=${extDir}`, `--load-extension=${extDir}`);
+
+const context = await chromium.launchPersistentContext(join(outDir, '.userdata'), {
+  headless: false,
+  args: launchArgs,
+  viewport: { width: windowW, height: windowH },
+  recordVideo: { dir: outDir, size: { width: windowW, height: windowH } },
+});
+const page = await context.newPage();
+if (extDir) await page.waitForTimeout(1500);
+
+await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+await page.waitForTimeout(seconds * 1000);
+
+// Snapshot final state for debugging.
+const debug = await page.evaluate(() => {
+  return Array.from(document.querySelectorAll('video')).map((v) => ({
+    src: (v.currentSrc || v.src || '').slice(0, 120),
+    paused: v.paused, currentTime: v.currentTime, readyState: v.readyState,
+    stillVideo: v.dataset.stillVideo || null,
+  }));
+});
+writeFileSync(join(outDir, 'debug-videos.json'), JSON.stringify(debug, null, 2));
+console.log('videos:', JSON.stringify(debug, null, 2));
+
+await page.screenshot({ path: join(outDir, 'final.png') }).catch(() => {});
+await page.close();
+await context.close();
+
+const files = readdirSync(outDir).filter((f) => f.endsWith('.webm'));
+if (files.length) renameSync(join(outDir, files[0]), join(outDir, 'recording.webm'));
+// Synthesize a frame_times.json for analyze.mts (it derives from webm if missing).
+writeFileSync(join(outDir, 'scroll_times.json'), JSON.stringify({ scrollTimes: [] }, null, 2));

--- a/tests/motion/scout.sh
+++ b/tests/motion/scout.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Scout for a Google search term that reliably triggers AR/video shopping
+# previews in the no-extension baseline. Records ONLY the "none" variant
+# (cuts run time in half) and stops as soon as meanMotion clears the
+# threshold — that's our reproduction case.
+#
+# Required env: AV_INDEX, WINDOW_X, WINDOW_Y (see list-displays.sh).
+# Optional env: SECONDS_RUN (default 25), MOTION_THRESHOLD (default 2.0).
+#
+# Usage:
+#   AV_INDEX=3 WINDOW_X=-2540 WINDOW_Y=-220 ./tests/motion/scout.sh
+#
+# After a hit, run the full comparison:
+#   AV_INDEX=3 WINDOW_X=-2540 WINDOW_Y=-220 \
+#     MODE=flicker-scroll ./tests/motion/run.sh "<hit-url>" 25
+
+set -euo pipefail
+
+: "${AV_INDEX:?AV_INDEX required}"
+: "${WINDOW_X:?WINDOW_X required}"
+: "${WINDOW_Y:?WINDOW_Y required}"
+SECONDS_RUN="${SECONDS_RUN:-25}"
+THRESH="${MOTION_THRESHOLD:-2.0}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COOKIES="$SCRIPT_DIR/cookies/google.com.json"
+COOKIES_ARGS=()
+[ -f "$COOKIES" ] && COOKIES_ARGS=(--cookies "$COOKIES")
+
+STAMP="$(date +%Y%m%d_%H%M%S)"
+SCOUT_DIR="$SCRIPT_DIR/reports/_scout_${STAMP}"
+mkdir -p "$SCOUT_DIR"
+
+# Search terms where AR / 3D / video product previews are most likely.
+# Ordered by guess of likelihood-of-firing.
+TERMS=(
+  "nike+air+force+1"
+  "iphone+15+pro"
+  "ps5+console"
+  "samsung+galaxy+s24"
+  "macbook+pro+m3"
+  "apple+watch"
+  "ikea+sofa"
+  "lego+technic"
+  "tesla+model+3"
+  "robot+vacuum"
+  "kitchenaid+stand+mixer"
+  "rolex+submariner"
+  "adidas+ultraboost"
+  "dyson+v15"
+  "wireless+earbuds"
+)
+
+echo "scouting ${#TERMS[@]} terms, threshold meanMotion>${THRESH}, seconds=${SECONDS_RUN}"
+echo "results in $SCOUT_DIR"
+echo ""
+
+HIT_URL=""
+HIT_MOTION=""
+for term in "${TERMS[@]}"; do
+  url="https://www.google.com/search?q=$term"
+  vdir="$SCOUT_DIR/$term"
+  mkdir -p "$vdir"
+  echo "=== $term ==="
+
+  # Use system Chrome — Google's SERP composition (Shopping/AR carousels)
+  # depends on the TLS fingerprint, and Playwright's bundled Chromium-for-
+  # Testing gets a stripped layout (no Shopping carousel, no AR videos).
+  npx tsx "$SCRIPT_DIR/capture-display.mts" \
+    --url "$url" --out "$vdir" --seconds "$SECONDS_RUN" \
+    --av-index "$AV_INDEX" --window-x "$WINDOW_X" --window-y "$WINDOW_Y" \
+    --scroll-then-sit --system-chrome \
+    ${COOKIES_ARGS[@]+"${COOKIES_ARGS[@]}"} \
+    > "$vdir/capture.log" 2>&1 || { echo "  capture failed"; continue; }
+  npx tsx "$SCRIPT_DIR/analyze.mts" --in "$vdir" > "$vdir/analyze.log" 2>&1 || true
+
+  if [ -f "$vdir/summary.json" ]; then
+    motion="$(jq -r '.meanMotion' "$vdir/summary.json")"
+    echo "  meanMotion = $motion"
+    # Bash float compare via awk — POSIX has no float ops natively.
+    if awk -v m="$motion" -v t="$THRESH" 'BEGIN { exit (m+0 > t+0) ? 0 : 1 }'; then
+      HIT_URL="$url"
+      HIT_MOTION="$motion"
+      echo ""
+      echo "** HIT: motion>${THRESH} on '$term' **"
+      echo "    url = $url"
+      echo "    dir = $vdir"
+      break
+    fi
+  else
+    echo "  (no summary)"
+  fi
+done
+
+echo ""
+if [ -n "$HIT_URL" ]; then
+  echo "Reproduction term found. To run the full comparison:"
+  echo "  AV_INDEX=$AV_INDEX WINDOW_X=$WINDOW_X WINDOW_Y=$WINDOW_Y \\"
+  echo "    MODE=flicker-scroll $SCRIPT_DIR/run.sh \"$HIT_URL\" $SECONDS_RUN"
+else
+  echo "No hit. All ${#TERMS[@]} terms had meanMotion<=${THRESH}."
+  echo "Inspect frames in: $SCOUT_DIR/<term>/frames/"
+fi

--- a/web-extension/content.js
+++ b/web-extension/content.js
@@ -61,6 +61,15 @@
     '  visibility: visible !important;',
     "  background: #e8e8e8 url(\"" + PLACEHOLDER + "\") center/contain no-repeat !important;",
     '  object-position: -9999px -9999px !important;',
+    '}',
+    // Inline video previews used as image substitutes (Google Shopping AR
+    // spin previews, e.g. `gstatic.com/search-ar-dev/...`) — hide once we've
+    // tagged them. visibility:hidden preserves layout so the sibling poster
+    // <img> in the same card stays in its slot. Pairs with blockVideoPreview()
+    // which pauses and neuters .play() so JS-driven hover/intersection
+    // handlers can't restart playback.
+    'video[data-still-video="blocked"] {',
+    '  visibility: hidden !important;',
     '}'
   ].join('\n');
   (document.head || document.documentElement).appendChild(style);
@@ -560,11 +569,48 @@
     });
   }
 
-  // --- Pause all videos ---
+  // --- Pause all videos + neuter image-substitute video previews ---
+
+  // URL patterns for inline videos used as animated-image substitutes —
+  // muted, playsinline, aria-hidden previews that ordinary autoplay blockers
+  // (Safari's built-in, StopTheMadness Pro) let through because there's no
+  // `autoplay` attribute and `muted+playsinline` is exempt under spec.
+  // First entry: Google Shopping's AR product spin previews on the SERP.
+  const VIDEO_PREVIEW_BLOCKLIST_RE = /\/\/[^/]*\.gstatic\.com\/search-ar-dev\//i;
+
+  function videoSrcs(v) {
+    const out = [];
+    if (v.currentSrc) out.push(v.currentSrc);
+    if (v.src) out.push(v.src);
+    v.querySelectorAll('source').forEach((s) => { if (s.src) out.push(s.src); });
+    return out;
+  }
+
+  function isVideoPreviewToBlock(v) {
+    return videoSrcs(v).some((s) => VIDEO_PREVIEW_BLOCKLIST_RE.test(s));
+  }
+
+  function blockVideoPreview(v) {
+    if (v.dataset.stillVideo === 'blocked') return;
+    v.dataset.stillVideo = 'blocked';
+    try { v.pause(); } catch (e) {}
+    try { v.removeAttribute('autoplay'); } catch (e) {}
+    // Override .play() on this specific element so JS-triggered playback
+    // (Google's IntersectionObserver / hover handlers) becomes a no-op.
+    // We resolve the returned Promise to keep callers from throwing.
+    try {
+      Object.defineProperty(v, 'play', {
+        value: function () { return Promise.resolve(); },
+        writable: false,
+        configurable: false,
+      });
+    } catch (e) {}
+  }
 
   function pauseVideos() {
     document.querySelectorAll('video').forEach((v) => {
       try { v.pause(); } catch (e) {}
+      if (isVideoPreviewToBlock(v)) blockVideoPreview(v);
     });
   }
 
@@ -606,9 +652,13 @@
                 processImage(node);
               } else if (node.tagName === 'VIDEO') {
                 try { node.pause(); } catch (e) {}
+                if (isVideoPreviewToBlock(node)) blockVideoPreview(node);
               } else if (node.querySelectorAll) {
                 node.querySelectorAll('img').forEach(processImage);
-                node.querySelectorAll('video').forEach((v) => { try { v.pause(); } catch (e) {} });
+                node.querySelectorAll('video').forEach((v) => {
+                  try { v.pause(); } catch (e) {}
+                  if (isVideoPreviewToBlock(v)) blockVideoPreview(v);
+                });
                 // Check for SVG animations in added subtree
                 if (node.tagName === 'SVG' || node.querySelector?.('svg, animate, animateTransform, animateMotion, set')) {
                   killSVGAnimations();
@@ -645,6 +695,16 @@
               target.removeAttribute('srcset');
               target.removeAttribute('src');
             }
+          }
+          // Late-bound video src — Google sometimes inserts <video> first then
+          // assigns src as the carousel scrolls into view. Re-check on src
+          // change so we still catch the AR-shopping pattern.
+          if (target.tagName === 'VIDEO' && target.dataset.stillVideo !== 'blocked') {
+            if (isVideoPreviewToBlock(target)) blockVideoPreview(target);
+          }
+          if (target.tagName === 'SOURCE' && target.parentElement?.tagName === 'VIDEO') {
+            const v = target.parentElement;
+            if (v.dataset.stillVideo !== 'blocked' && isVideoPreviewToBlock(v)) blockVideoPreview(v);
           }
         }
       }
@@ -749,6 +809,7 @@
       isSpacer, isAnimatedDataGif,
       scanAll, scanBackgroundImages, killSVGAnimations, flaggedAnimatedURLs,
       cancelAnimations,
+      isVideoPreviewToBlock, blockVideoPreview, pauseVideos,
     };
   }
 

--- a/web-extension/content.js
+++ b/web-extension/content.js
@@ -63,13 +63,16 @@
     '  object-position: -9999px -9999px !important;',
     '}',
     // Inline video previews used as image substitutes (Google Shopping AR
-    // spin previews, e.g. `gstatic.com/search-ar-dev/...`) — hide once we've
-    // tagged them. visibility:hidden preserves layout so the sibling poster
-    // <img> in the same card stays in its slot. Pairs with blockVideoPreview()
-    // which pauses and neuters .play() so JS-driven hover/intersection
-    // handlers can't restart playback.
+    // spin previews, e.g. `gstatic.com/search-ar-dev/...`). display:none
+    // (not visibility:hidden) — Google's product cards position the video
+    // absolutely over the static poster <img>, so removing it from layout
+    // doesn't shift anything. visibility:hidden was leaking visible motion
+    // (user report 2026-05-09) — likely because the video element kept a
+    // composited layer that decoded frames even while "invisible". Pairs
+    // with blockVideoPreview() which pauses and neuters .play() so JS-
+    // driven hover/intersection handlers can't restart playback.
     'video[data-still-video="blocked"] {',
-    '  visibility: hidden !important;',
+    '  display: none !important;',
     '}'
   ].join('\n');
   (document.head || document.documentElement).appendChild(style);

--- a/web-extension/main-world-patch.js
+++ b/web-extension/main-world-patch.js
@@ -19,6 +19,17 @@
  * elements with that attribute.
  */
 (function () {
+  // Marker so we can tell from outside whether this main-world script
+  // ever ran on a page. Useful when diagnosing CSP / world:MAIN drops on
+  // sites with strict CSPs (Google's `require-trusted-types-for 'script'`
+  // is the canonical case) — without this marker the only way to tell is
+  // observing prototype.play.toString() at runtime, which is racy.
+  try {
+    if (document && document.documentElement) {
+      document.documentElement.setAttribute('data-still-mwp', 'loaded');
+    }
+  } catch (e) {}
+
   const SETTLE_MS = 300;
   const svgSettleTimers = new WeakMap();
   const origSetAttribute = Element.prototype.setAttribute;

--- a/web-extension/main-world-patch.js
+++ b/web-extension/main-world-patch.js
@@ -98,20 +98,49 @@
   defineJQueryGlobal('jQuery');
   defineJQueryGlobal('$');
 
-  // --- HTMLMediaElement.play() interception for tagged image-substitute videos ---
+  // --- HTMLMediaElement.play() interception for image-substitute videos ---
   // Inline <video> previews used as animated-GIF substitutes (Google Shopping
   // AR spin previews on the SERP, etc.) bypass autoplay blockers because they
   // ship with `muted+playsinline` (spec-exempt) and no `autoplay` attribute —
-  // the page calls `.play()` from an IntersectionObserver/hover handler. Our
-  // content script (isolated world) tags those elements with
-  // `data-still-video="blocked"`, but its property override on `play` doesn't
-  // apply when page script calls `play()` from this main world. So we patch
-  // the prototype here, gated by the data attribute (which IS shared across
-  // worlds because it's a real DOM attribute).
+  // the page calls `.play()` from an IntersectionObserver/hover handler.
+  //
+  // We catch them two ways here, both synchronous to the .play() call so
+  // there's no window in which a video can slip through:
+  //   1. data-still-video="blocked" attribute (set by content.js when it
+  //      walks the DOM; also set by us below when we match by URL).
+  //   2. URL pattern check on src / currentSrc / <source> children. This is
+  //      the race-safe path: Google inserts a video card and calls .play()
+  //      in the SAME tick, before content.js's MutationObserver fires. If we
+  //      gated only on the tag, the first .play() call would slip through
+  //      (user reported: "after I scrolled down and started hovering, later
+  //      stuff started playing"). The URL check runs before content.js has
+  //      to do anything.
+  const VIDEO_PREVIEW_BLOCKLIST_RE = /\/\/[^/]*\.gstatic\.com\/search-ar-dev\//i;
+  function srcMatchesBlocklist(v) {
+    const csrc = v.currentSrc;
+    if (csrc && VIDEO_PREVIEW_BLOCKLIST_RE.test(csrc)) return true;
+    const src = v.getAttribute && v.getAttribute('src');
+    if (src && VIDEO_PREVIEW_BLOCKLIST_RE.test(src)) return true;
+    if (v.querySelectorAll) {
+      const sources = v.querySelectorAll('source');
+      for (let i = 0; i < sources.length; i++) {
+        const ss = sources[i].getAttribute && sources[i].getAttribute('src');
+        if (ss && VIDEO_PREVIEW_BLOCKLIST_RE.test(ss)) return true;
+      }
+    }
+    return false;
+  }
   const origMediaPlay = HTMLMediaElement.prototype.play;
   HTMLMediaElement.prototype.play = function () {
-    if (this.getAttribute && this.getAttribute('data-still-video') === 'blocked') {
+    const tagged = this.getAttribute && this.getAttribute('data-still-video') === 'blocked';
+    if (tagged || srcMatchesBlocklist(this)) {
       try { this.pause(); } catch (e) {}
+      // Tag the element so the CSS hide rule + MutationObserver re-checks
+      // also see it. setAttribute writes a real DOM attribute that's visible
+      // to the isolated-world content script too.
+      try {
+        if (!tagged && this.setAttribute) this.setAttribute('data-still-video', 'blocked');
+      } catch (e) {}
       return Promise.resolve();
     }
     return origMediaPlay.apply(this, arguments);

--- a/web-extension/main-world-patch.js
+++ b/web-extension/main-world-patch.js
@@ -97,4 +97,23 @@
   }
   defineJQueryGlobal('jQuery');
   defineJQueryGlobal('$');
+
+  // --- HTMLMediaElement.play() interception for tagged image-substitute videos ---
+  // Inline <video> previews used as animated-GIF substitutes (Google Shopping
+  // AR spin previews on the SERP, etc.) bypass autoplay blockers because they
+  // ship with `muted+playsinline` (spec-exempt) and no `autoplay` attribute —
+  // the page calls `.play()` from an IntersectionObserver/hover handler. Our
+  // content script (isolated world) tags those elements with
+  // `data-still-video="blocked"`, but its property override on `play` doesn't
+  // apply when page script calls `play()` from this main world. So we patch
+  // the prototype here, gated by the data attribute (which IS shared across
+  // worlds because it's a real DOM attribute).
+  const origMediaPlay = HTMLMediaElement.prototype.play;
+  HTMLMediaElement.prototype.play = function () {
+    if (this.getAttribute && this.getAttribute('data-still-video') === 'blocked') {
+      try { this.pause(); } catch (e) {}
+      return Promise.resolve();
+    }
+    return origMediaPlay.apply(this, arguments);
+  };
 })();

--- a/web-extension/manifest.json
+++ b/web-extension/manifest.json
@@ -27,6 +27,11 @@
         "id": "ruleset_apng",
         "enabled": false,
         "path": "rules/ruleset_apng.json"
+      },
+      {
+        "id": "ruleset_ar_video",
+        "enabled": true,
+        "path": "rules/ruleset_ar_video.json"
       }
     ]
   },

--- a/web-extension/manifest.json
+++ b/web-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Still",
-  "version": "1.3",
+  "version": "1.4",
   "description": "Block animated GIFs, WebP, and APNG. Pause autoplay video. Cancel CSS animations.",
   "permissions": [
     "activeTab",

--- a/web-extension/rules/ruleset_ar_video.json
+++ b/web-extension/rules/ruleset_ar_video.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": 1,
+    "priority": 1,
+    "action": { "type": "block" },
+    "condition": {
+      "urlFilter": "||gstatic.com/search-ar-dev/",
+      "resourceTypes": ["media", "image", "xmlhttprequest", "other"]
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Blocks the autoplay product-spin `<video>` previews on Google Shopping carousels (`gstatic.com/search-ar-dev/.../square_video.mp4`). They look like animated GIFs but bypass autoplay blockers — no `autoplay` attribute, `muted+playsinline` is spec-exempt, `.play()` is fired from a JS IntersectionObserver / hover handler.
- Two-layer defense: content.js tags matching elements with `data-still-video="blocked"` + CSS hides them; `main-world-patch.js` patches `HTMLMediaElement.prototype.play` to no-op when the element is tagged **OR** its src matches the URL pattern (race-safe — catches lazy-inserted videos that page JS plays in the same tick they're inserted).
- Synced into `Still/Still Extension/Resources/` for iOS. Same `world: MAIN` caveat as the existing SVG / jQuery main-world patches (Safari iOS 18.4+ for the prototype patch; CSS hide works on all supported versions).
- Two new tests (`tests/freeze.spec.js:1264`, `:1337`) — happy path + race-safe regression.
- Motion-harness tooling: `diagnose.mts` (forensic image/video reporter), `headed-record.mts` (works around revoked AVFoundation TCC permission), `scout.sh` (iterates search terms looking for live motion), `fixture/ar-shopping-mock.html` (deterministic reproduction using real gstatic mp4 URLs), `capture-display.mts` `--force-play-videos` flag.

## Pixel-level proof
Recorded with vs. without the extension on the AR-shopping fixture (15 s, after the t=1.5 s settle):

| | no extension | with fix |
|---|---:|---:|
| meanMotion | 0.6726 | 0.0440 |
| frames moving (>0.5) | 67 % | 3 % |
| frames moving (>2.0) | 4 | **0** |
| max motion | 14.52 | 1.43 |

## Test plan
- [x] `npx playwright test` — 35/35 pass (added: `:1264`, `:1337`)
- [x] Manual fixture comparison via `headed-record.mts` — videos visibly stop animating with extension loaded
- [ ] User to verify on real Google Shopping (e.g. `nike air max`, `dish drain rack`) with the extension enabled, including scroll + hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)