### PR TITLE
Block homedepot Memorial Day animation (canvas + spacer); v1.4 polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ build/
 tests/motion/reports/
 tests/motion/cookies/
 
+# Browser-generated declarativeNetRequest indexed rulesets
+web-extension/_metadata/
+
 # Claude Code local state
 .claude/

--- a/Still/Still/Still Extension/Resources/content.js
+++ b/Still/Still/Still Extension/Resources/content.js
@@ -73,6 +73,27 @@
     // driven hover/intersection handlers can't restart playback.
     'video[data-still-video="blocked"] {',
     '  display: none !important;',
+    '}',
+    // Canvas animation detector (main-world-patch.js).
+    //
+    // We hide EVERY canvas by default until the detector classifies it,
+    // because a migraine-safe extension can't afford to show even one
+    // frame of a fast-paint animation. Classification happens within
+    // ~200 ms of the page first touching the canvas (its getContext call):
+    //   - probing  → still measuring; stay hidden (visibility:hidden so
+    //                layout is preserved for legitimate charts/maps).
+    //   - blocked  → ≥3 frames drawn in the probe window; this is an
+    //                rAF-driven animation. display:none + draw no-ops in
+    //                the main-world patch save the rAF loop's work too.
+    //   - static   → drew ≤2 frames; safe to reveal.
+    // Selector form `canvas:not([data-still-canvas="static"])` covers both
+    // unclassified canvases (the brief moment between page parse and
+    // getContext) and "probing" canvases with one rule.
+    'canvas:not([data-still-canvas="static"]) {',
+    '  visibility: hidden !important;',
+    '}',
+    'canvas[data-still-canvas="blocked"] {',
+    '  display: none !important;',
     '}'
   ].join('\n');
   (document.head || document.documentElement).appendChild(style);

--- a/Still/Still/Still Extension/Resources/content.js
+++ b/Still/Still/Still Extension/Resources/content.js
@@ -384,13 +384,20 @@
     // let a real animated GIF leak through after a lazy-load swap from a
     // 1×1 placeholder (whose nw/nh briefly remain as 1×1).
     if (img.complete && nw > 0 && nh > 0 && nw <= 1 && nh <= 1) return true;
-    // Check HTML attributes (width="1" height="1")
+    // HTML width="1" height="1" attrs. Only trust alongside natural-dim
+    // confirmation: homedepot.com sets width="1" height="1" on real `<img>`
+    // elements that CSS (`sui-w-full sui-h-full`) sizes to the container,
+    // so the attrs are a layout placeholder, not a 1×1 spacer. Without
+    // natural-dim corroboration we'd mark a 1814×504 animated hero static.
     const aw = parseInt(img.getAttribute('width'), 10);
     const ah = parseInt(img.getAttribute('height'), 10);
-    if (aw <= 1 && ah <= 1 && aw > 0 && ah > 0) return true;
-    // Check if the element is invisible (zero layout size) — but only if
-    // natural dimensions confirm it's truly tiny (not just unloaded/hidden)
-    if (img.offsetWidth === 0 && img.offsetHeight === 0 && nw > 0 && nh > 0) return true;
+    if (aw <= 1 && ah <= 1 && aw > 0 && ah > 0 &&
+        img.complete && nw > 0 && nh > 0 && nw <= 4 && nh <= 4) return true;
+    // Zero layout size + tiny natural — collapsed-parent genuine spacer.
+    // Don't catch large-natural images in collapsed parents: those are
+    // real images temporarily hidden by their layout chain, not spacers.
+    if (img.offsetWidth === 0 && img.offsetHeight === 0 &&
+        nw > 0 && nh > 0 && nw <= 4 && nh <= 4) return true;
     // Filename hints — classic spacer names (1x1.trans.gif, blank.gif, etc.).
     // Narrow match: spacer keyword must be the filename basename, not a prefix.
     const src = img.currentSrc || img.src || '';

--- a/Still/Still/Still Extension/Resources/main-world-patch.js
+++ b/Still/Still/Still Extension/Resources/main-world-patch.js
@@ -156,4 +156,104 @@
     }
     return origMediaPlay.apply(this, arguments);
   };
+
+  // --- Canvas animation detector ---
+  // Decorative canvas animations (confetti, particle backgrounds, WebGL
+  // hero scenes) draw new pixels every rAF tick. URL rules can't catch
+  // them, image scanning can't see canvas pixels, getAnimations() doesn't
+  // know about them, and there's no <video>/<img> hook. The defining
+  // invariant: they keep drawing.
+  //
+  // Migraine-safety constraint: never show even a single animated frame.
+  // So we mirror the .gif "probing" pattern — every canvas is hidden by
+  // default (CSS rule in content.js: `canvas:not([data-still-canvas="static"])
+  // { visibility: hidden !important }`), and we classify each one within
+  // a short probe window:
+  //   - probing: hidden, count frames
+  //   - threshold reached → blocked: display:none, no-op subsequent draws
+  //   - probe window expires under threshold → static: revealed
+  //
+  // Interactive canvases (maps, charts, games) typically render 1–2 frames
+  // at setup and then idle until user input, so they classify as static and
+  // are free to redraw under interaction without retriggering us.
+  const PROBE_WINDOW_MS = 200;
+  const FRAME_THRESHOLD = 3;
+  const SAME_FRAME_DEBOUNCE_MS = 5;
+  const canvasStats = new WeakMap();
+
+  function classify(canvas) {
+    if (!canvas || canvas.getAttribute('data-still-canvas') !== 'probing') return;
+    const s = canvasStats.get(canvas);
+    const frames = s ? s.frames : 0;
+    try {
+      canvas.setAttribute('data-still-canvas', frames >= FRAME_THRESHOLD ? 'blocked' : 'static');
+    } catch (e) {}
+  }
+
+  function instrumentCanvas(canvas) {
+    if (!canvas || canvas.getAttribute('data-still-canvas')) return;
+    try { canvas.setAttribute('data-still-canvas', 'probing'); } catch (e) {}
+    canvasStats.set(canvas, { last: 0, frames: 0 });
+    setTimeout(() => classify(canvas), PROBE_WINDOW_MS);
+  }
+
+  function recordDraw(canvas) {
+    if (!canvas) return false;
+    const state = canvas.getAttribute('data-still-canvas');
+    if (state === 'blocked') return true; // signal: skip the draw entirely
+    if (!state) instrumentCanvas(canvas);
+    else if (state !== 'probing') return false; // static — leave it alone
+    const s = canvasStats.get(canvas);
+    if (!s) return false;
+    const now = performance.now();
+    if (now - s.last < SAME_FRAME_DEBOUNCE_MS) return false;
+    s.last = now;
+    s.frames++;
+    // Cross threshold mid-probe → block immediately, no point waiting for
+    // the timer.
+    if (s.frames >= FRAME_THRESHOLD) {
+      try { canvas.setAttribute('data-still-canvas', 'blocked'); } catch (e) {}
+      return true;
+    }
+    return false;
+  }
+
+  // getContext is the universal entry-point — every canvas that draws goes
+  // through it. Instrumenting here means we mark "probing" the instant a
+  // page touches a canvas, before the first draw call lands.
+  const origGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function () {
+    instrumentCanvas(this);
+    return origGetContext.apply(this, arguments);
+  };
+
+  function patchDrawMethods(proto, methods) {
+    if (!proto) return;
+    methods.forEach((m) => {
+      const orig = proto[m];
+      if (typeof orig !== 'function') return;
+      proto[m] = function () {
+        const skip = recordDraw(this && this.canvas);
+        if (skip) return; // blocked: no-op (saves CPU on the rAF loop)
+        return orig.apply(this, arguments);
+      };
+    });
+  }
+
+  if (typeof CanvasRenderingContext2D !== 'undefined') {
+    patchDrawMethods(CanvasRenderingContext2D.prototype, [
+      'clearRect', 'fillRect', 'strokeRect',
+      'drawImage', 'fill', 'stroke',
+      'fillText', 'strokeText', 'putImageData',
+    ]);
+  }
+  if (typeof WebGLRenderingContext !== 'undefined') {
+    patchDrawMethods(WebGLRenderingContext.prototype, ['drawArrays', 'drawElements']);
+  }
+  if (typeof WebGL2RenderingContext !== 'undefined') {
+    patchDrawMethods(WebGL2RenderingContext.prototype, [
+      'drawArrays', 'drawElements',
+      'drawArraysInstanced', 'drawElementsInstanced',
+    ]);
+  }
 })();

--- a/app-store/description.md
+++ b/app-store/description.md
@@ -3,6 +3,7 @@ Still blocks animated images and motion effects in Safari, giving you a calm, st
 What it blocks:
 • Animated GIFs — replaced with a static placeholder. Includes GIFs served via image-proxy URLs (Next.js, Cloudinary) and cross-origin CDNs that often slip past simpler blockers
 • Animated WebP and APNG — detected by inspecting file headers; static images display normally
+• Inline video product previews used as animated-image substitutes — Google Shopping's spinning 3D product cards and similar muted, autoplaying clips that bypass Safari's autoplay control
 • CSS transitions that create subliminal smooth motion (carousel crossfades, opacity pulses, sliding banners)
 • CSS background-image animations
 • SVG animations

--- a/app-store/release-notes-v1.4.md
+++ b/app-store/release-notes-v1.4.md
@@ -1,0 +1,5 @@
+• Stops the spinning 3D product previews on Google Shopping search results. These silently auto-rotating product cards bypass Safari's autoplay control because they ship as muted, inline videos rather than animated images — Still now blocks them at the network and DOM layers.
+
+• Even on long, fast-scrolling result pages, product spinners are caught the moment they appear. A previous timing window briefly let cards play before being blocked; the new defense gates on the video URL itself, so there's no race.
+
+• Polish: blocked video previews are now fully removed from page layout, eliminating a case where the browser kept rendering frames on a "hidden" video element and leaving subtle motion visible.

--- a/tests/freeze.spec.js
+++ b/tests/freeze.spec.js
@@ -1360,6 +1360,135 @@ test.describe('Still — block and replace logic', () => {
     expect(result.okIntercepted).toBe(false);
   });
 
+  test('hides a canvas that draws via rAF (confetti / particle-bg pattern) and reveals a static one', async ({ page }) => {
+    // canvas-confetti (catdad/canvas-confetti) and similar particle libraries
+    // append a <canvas> and run an rAF loop that clearRect+fillRect every
+    // tick. They have no URL extension, no <img>, no <video>, no
+    // CSS-keyframe / Web Animations hook — the rest of our pipeline misses
+    // them entirely. The defense:
+    //   1. main-world-patch.js wraps CanvasRenderingContext2D and WebGL
+    //      draw methods; the first getContext call marks the canvas
+    //      data-still-canvas="probing".
+    //   2. content.js CSS hides every canvas that is not "static".
+    //   3. After 200 ms (or sooner, if ≥3 frames have already drawn), the
+    //      canvas is classified blocked (display:none + draws no-op) or
+    //      static (revealed).
+    const fs = require('fs');
+    const mainWorldPatch = fs.readFileSync(MAIN_WORLD_PATCH, 'utf8');
+    const contentJs = fs.readFileSync(CONTENT_SCRIPT, 'utf8');
+    await page.setContent(`
+      <!DOCTYPE html>
+      <script>
+        window.browser = {
+          storage: { local: {
+            get(keys, cb) { cb({ enabled: true, allowlist: [] }); },
+            set() {},
+          }},
+          runtime: { onMessage: { addListener() {} }, sendMessage() { return Promise.resolve(); }, getURL(p){ return ''; } },
+        };
+      </script>
+      <script>${mainWorldPatch}</script>
+      <script>${contentJs}</script>
+      <body>
+        <canvas id="anim" width="200" height="200"></canvas>
+        <canvas id="static" width="200" height="200"></canvas>
+        <script>
+          // Animated canvas — clear + fill every rAF tick, indefinitely.
+          (function () {
+            const c = document.getElementById('anim');
+            const ctx = c.getContext('2d');
+            (function tick() {
+              ctx.clearRect(0, 0, 200, 200);
+              ctx.fillStyle = 'red';
+              ctx.fillRect(Math.random() * 180, Math.random() * 180, 20, 20);
+              requestAnimationFrame(tick);
+            })();
+          })();
+          // Static canvas — one draw, no rAF loop.
+          (function () {
+            const c = document.getElementById('static');
+            const ctx = c.getContext('2d');
+            ctx.fillStyle = 'blue';
+            ctx.fillRect(0, 0, 200, 200);
+          })();
+        </script>
+      </body>
+    `);
+    // Wait past the 200ms probe window plus margin.
+    await page.waitForTimeout(500);
+
+    const result = await page.evaluate(() => {
+      const a = document.getElementById('anim');
+      const s = document.getElementById('static');
+      return {
+        animState: a.getAttribute('data-still-canvas'),
+        animDisplay: getComputedStyle(a).display,
+        animVisibility: getComputedStyle(a).visibility,
+        staticState: s.getAttribute('data-still-canvas'),
+        staticVisibility: getComputedStyle(s).visibility,
+      };
+    });
+    expect(result.animState).toBe('blocked');
+    expect(result.animDisplay).toBe('none');
+    expect(result.staticState).toBe('static');
+    expect(result.staticVisibility).toBe('visible');
+  });
+
+  test('canvas animation never paints a single visible frame (pixel sampler)', async ({ page }) => {
+    // The above test proves the END-STATE is correct. This one proves NO
+    // FRAMES leak through during the probe window. rAF sampler records the
+    // canvas's computed visibility/display every paint; we assert no sample
+    // ever shows the canvas painted (animated AND visible) before block.
+    const fs = require('fs');
+    const mainWorldPatch = fs.readFileSync(MAIN_WORLD_PATCH, 'utf8');
+    const contentJs = fs.readFileSync(CONTENT_SCRIPT, 'utf8');
+    await page.setContent(`
+      <!DOCTYPE html>
+      <script>
+        window.browser = {
+          storage: { local: {
+            get(keys, cb) { cb({ enabled: true, allowlist: [] }); },
+            set() {},
+          }},
+          runtime: { onMessage: { addListener() {} }, sendMessage() { return Promise.resolve(); }, getURL(p){ return ''; } },
+        };
+      </script>
+      <script>${mainWorldPatch}</script>
+      <script>${contentJs}</script>
+      <body>
+        <canvas id="c" width="200" height="200"></canvas>
+        <script>
+          window.__samples = [];
+          (function () {
+            const c = document.getElementById('c');
+            const ctx = c.getContext('2d');
+            (function tick() {
+              ctx.clearRect(0, 0, 200, 200);
+              ctx.fillStyle = 'red';
+              ctx.fillRect(Math.random() * 180, Math.random() * 180, 20, 20);
+              const cs = getComputedStyle(c);
+              window.__samples.push({
+                t: performance.now(),
+                visibility: cs.visibility,
+                display: cs.display,
+                state: c.getAttribute('data-still-canvas'),
+              });
+              requestAnimationFrame(tick);
+            })();
+          })();
+        </script>
+      </body>
+    `);
+    await page.waitForTimeout(500);
+    const samples = await page.evaluate(() => window.__samples);
+    expect(samples.length).toBeGreaterThan(3);
+    // Every sample must be either visibility:hidden OR display:none.
+    // visibility:visible AND display!=none would mean the canvas was on
+    // screen with newly-drawn pixels — exactly what we can't let through.
+    const leaks = samples.filter((s) => s.visibility === 'visible' && s.display !== 'none');
+    expect(leaks).toEqual([]);
+  });
+
   test('blocks lazy-inserted gstatic AR videos that are .play()ed in the same tick (race-safe)', async ({ page }) => {
     // Race the user reported in real Chrome: initial-viewport videos got
     // blocked, but "after I scrolled down and started hovering, later stuff

--- a/tests/freeze.spec.js
+++ b/tests/freeze.spec.js
@@ -856,6 +856,32 @@ test.describe('Still — block and replace logic', () => {
     expect(src).toMatch(/^data:image\/svg\+xml/); // replaced, not leaked
   });
 
+  test('STILL replaces a real GIF with width="1" height="1" HTML attrs (homedepot CSS-sizing pattern)', async ({ page }) => {
+    // homedepot.com renders <img width="1" height="1" class="sui-w-full sui-h-full">
+    // as a layout placeholder — utility CSS sizes the image to its container.
+    // Before the fix, isSpacer trusted the 1×1 HTML attrs alone and marked the
+    // 1814×504 Memorial Day hero GIF as static at document_start, before load.
+    await injectContentScript(page);
+    await page.goto(baseURL + '/test-page.html');
+    await page.evaluate((base) => {
+      const img = document.createElement('img');
+      img.id = 'img-css-sized-hero';
+      img.setAttribute('width', '1');
+      img.setAttribute('height', '1');
+      img.style.width = '800px';
+      img.style.height = '200px';
+      img.src = base + '/fixtures/test-slow.gif';
+      document.body.appendChild(img);
+    }, baseURL);
+    await page.addScriptTag({ path: CONTENT_SCRIPT });
+    await page.waitForFunction(
+      () => document.getElementById('img-css-sized-hero').dataset.still === 'replaced',
+      { timeout: 3000 }
+    );
+    const src = await page.$eval('#img-css-sized-hero', (el) => el.src);
+    expect(src).toMatch(/^data:image\/svg\+xml/);
+  });
+
   test('extensionless URL serving animated GIF: no visible-render window before block', async ({ page }) => {
     // Extensionless URLs (image CDNs that strip .gif/.webp, proxied images, etc.)
     // bypass our document_start CSS hide rule because the rule pattern-matches

--- a/tests/motion/fixture/ar-shopping-race.html
+++ b/tests/motion/fixture/ar-shopping-race.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Still motion-test fixture: race-condition AR videos</title>
+<style>
+  body { margin: 0; padding: 24px; background: #1a1a1a; color: #eee;
+         font: 14px/1.4 -apple-system, system-ui, sans-serif; }
+  h1   { margin: 0 0 12px; font-size: 18px; font-weight: 500; }
+  p    { margin: 0 0 18px; color: #aaa; }
+  .grid { display: grid; grid-template-columns: repeat(4, 159px);
+          gap: 16px; min-height: 220px; }
+  .card { background: #2a2a2a; padding: 8px; border-radius: 4px;
+          width: 159px; height: 215px; }
+  video { width: 159px; height: 199px; background: #444; display: block; }
+  .label { font-size: 11px; color: #888; margin-top: 4px;
+           white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+</style>
+</head>
+<body>
+<h1>Race-condition fixture: lazy-inserted AR videos</h1>
+<p>Reproduces the race that real Google Shopping hit: a card scrolls into
+view (or you hover), Google's JS inserts a &lt;video&gt; element AND
+synchronously calls <code>.play()</code> on it in the same tick — before
+the extension's MutationObserver has a chance to tag it. The earlier
+defense (gated only on the data-still-video attribute) leaked here. The
+race-safe defense (gates on the src URL too, synchronously inside the
+play() override) catches it.</p>
+
+<div id="slot" class="grid"></div>
+
+<script>
+  // Real gstatic AR mp4 URLs harvested from prior live-SERP captures.
+  const URLS = [
+    'https://www.gstatic.com/search-ar-dev/renders/7288397677794265388_ml/7834519064935726986_v5/square_video.mp4',
+    'https://www.gstatic.com/search-ar-dev/renders/14970581154744047088_ml/9792256154545184134_v5/square_video.mp4',
+    'https://www.gstatic.com/search-ar-dev/renders/9680629773273341113_ml/9831554337451611906_v5/square_video.mp4',
+    'https://www.gstatic.com/search-ar-dev/renders/69f3e6342f0272c8/spin_square.mp4',
+  ];
+
+  // Wait 2s, then create + insert + play() each video in one synchronous
+  // block per video. This is the exact pattern Google's IntersectionObserver
+  // uses. Each loop iteration runs to completion before the microtask queue
+  // drains — so the extension's MutationObserver doesn't run until AFTER
+  // .play() has already been called on the new element.
+  setTimeout(() => {
+    const slot = document.getElementById('slot');
+    URLS.forEach((url, i) => {
+      const card = document.createElement('div');
+      card.className = 'card';
+      const v = document.createElement('video');
+      v.muted = true;
+      v.playsInline = true;
+      v.setAttribute('preload', 'none');
+      v.setAttribute('aria-hidden', 'true');
+      v.setAttribute('disableremoteplayback', '');
+      v.src = url;
+      card.appendChild(v);
+      const label = document.createElement('div');
+      label.className = 'label';
+      label.textContent = 'race-' + (i + 1);
+      card.appendChild(label);
+      slot.appendChild(card);
+      // SYNCHRONOUS .play() in the same tick as insertion — no microtask
+      // boundary here. This is what content.js's MutationObserver loses
+      // the race against.
+      v.play().catch(() => {});
+      // Also re-trigger on end to keep the recording window full of motion.
+      v.addEventListener('ended', () => v.play().catch(() => {}));
+    });
+  }, 2000);
+</script>
+</body>
+</html>

--- a/web-extension/content.js
+++ b/web-extension/content.js
@@ -73,6 +73,27 @@
     // driven hover/intersection handlers can't restart playback.
     'video[data-still-video="blocked"] {',
     '  display: none !important;',
+    '}',
+    // Canvas animation detector (main-world-patch.js).
+    //
+    // We hide EVERY canvas by default until the detector classifies it,
+    // because a migraine-safe extension can't afford to show even one
+    // frame of a fast-paint animation. Classification happens within
+    // ~200 ms of the page first touching the canvas (its getContext call):
+    //   - probing  → still measuring; stay hidden (visibility:hidden so
+    //                layout is preserved for legitimate charts/maps).
+    //   - blocked  → ≥3 frames drawn in the probe window; this is an
+    //                rAF-driven animation. display:none + draw no-ops in
+    //                the main-world patch save the rAF loop's work too.
+    //   - static   → drew ≤2 frames; safe to reveal.
+    // Selector form `canvas:not([data-still-canvas="static"])` covers both
+    // unclassified canvases (the brief moment between page parse and
+    // getContext) and "probing" canvases with one rule.
+    'canvas:not([data-still-canvas="static"]) {',
+    '  visibility: hidden !important;',
+    '}',
+    'canvas[data-still-canvas="blocked"] {',
+    '  display: none !important;',
     '}'
   ].join('\n');
   (document.head || document.documentElement).appendChild(style);

--- a/web-extension/content.js
+++ b/web-extension/content.js
@@ -384,13 +384,20 @@
     // let a real animated GIF leak through after a lazy-load swap from a
     // 1×1 placeholder (whose nw/nh briefly remain as 1×1).
     if (img.complete && nw > 0 && nh > 0 && nw <= 1 && nh <= 1) return true;
-    // Check HTML attributes (width="1" height="1")
+    // HTML width="1" height="1" attrs. Only trust alongside natural-dim
+    // confirmation: homedepot.com sets width="1" height="1" on real `<img>`
+    // elements that CSS (`sui-w-full sui-h-full`) sizes to the container,
+    // so the attrs are a layout placeholder, not a 1×1 spacer. Without
+    // natural-dim corroboration we'd mark a 1814×504 animated hero static.
     const aw = parseInt(img.getAttribute('width'), 10);
     const ah = parseInt(img.getAttribute('height'), 10);
-    if (aw <= 1 && ah <= 1 && aw > 0 && ah > 0) return true;
-    // Check if the element is invisible (zero layout size) — but only if
-    // natural dimensions confirm it's truly tiny (not just unloaded/hidden)
-    if (img.offsetWidth === 0 && img.offsetHeight === 0 && nw > 0 && nh > 0) return true;
+    if (aw <= 1 && ah <= 1 && aw > 0 && ah > 0 &&
+        img.complete && nw > 0 && nh > 0 && nw <= 4 && nh <= 4) return true;
+    // Zero layout size + tiny natural — collapsed-parent genuine spacer.
+    // Don't catch large-natural images in collapsed parents: those are
+    // real images temporarily hidden by their layout chain, not spacers.
+    if (img.offsetWidth === 0 && img.offsetHeight === 0 &&
+        nw > 0 && nh > 0 && nw <= 4 && nh <= 4) return true;
     // Filename hints — classic spacer names (1x1.trans.gif, blank.gif, etc.).
     // Narrow match: spacer keyword must be the filename basename, not a prefix.
     const src = img.currentSrc || img.src || '';

--- a/web-extension/main-world-patch.js
+++ b/web-extension/main-world-patch.js
@@ -156,4 +156,104 @@
     }
     return origMediaPlay.apply(this, arguments);
   };
+
+  // --- Canvas animation detector ---
+  // Decorative canvas animations (confetti, particle backgrounds, WebGL
+  // hero scenes) draw new pixels every rAF tick. URL rules can't catch
+  // them, image scanning can't see canvas pixels, getAnimations() doesn't
+  // know about them, and there's no <video>/<img> hook. The defining
+  // invariant: they keep drawing.
+  //
+  // Migraine-safety constraint: never show even a single animated frame.
+  // So we mirror the .gif "probing" pattern — every canvas is hidden by
+  // default (CSS rule in content.js: `canvas:not([data-still-canvas="static"])
+  // { visibility: hidden !important }`), and we classify each one within
+  // a short probe window:
+  //   - probing: hidden, count frames
+  //   - threshold reached → blocked: display:none, no-op subsequent draws
+  //   - probe window expires under threshold → static: revealed
+  //
+  // Interactive canvases (maps, charts, games) typically render 1–2 frames
+  // at setup and then idle until user input, so they classify as static and
+  // are free to redraw under interaction without retriggering us.
+  const PROBE_WINDOW_MS = 200;
+  const FRAME_THRESHOLD = 3;
+  const SAME_FRAME_DEBOUNCE_MS = 5;
+  const canvasStats = new WeakMap();
+
+  function classify(canvas) {
+    if (!canvas || canvas.getAttribute('data-still-canvas') !== 'probing') return;
+    const s = canvasStats.get(canvas);
+    const frames = s ? s.frames : 0;
+    try {
+      canvas.setAttribute('data-still-canvas', frames >= FRAME_THRESHOLD ? 'blocked' : 'static');
+    } catch (e) {}
+  }
+
+  function instrumentCanvas(canvas) {
+    if (!canvas || canvas.getAttribute('data-still-canvas')) return;
+    try { canvas.setAttribute('data-still-canvas', 'probing'); } catch (e) {}
+    canvasStats.set(canvas, { last: 0, frames: 0 });
+    setTimeout(() => classify(canvas), PROBE_WINDOW_MS);
+  }
+
+  function recordDraw(canvas) {
+    if (!canvas) return false;
+    const state = canvas.getAttribute('data-still-canvas');
+    if (state === 'blocked') return true; // signal: skip the draw entirely
+    if (!state) instrumentCanvas(canvas);
+    else if (state !== 'probing') return false; // static — leave it alone
+    const s = canvasStats.get(canvas);
+    if (!s) return false;
+    const now = performance.now();
+    if (now - s.last < SAME_FRAME_DEBOUNCE_MS) return false;
+    s.last = now;
+    s.frames++;
+    // Cross threshold mid-probe → block immediately, no point waiting for
+    // the timer.
+    if (s.frames >= FRAME_THRESHOLD) {
+      try { canvas.setAttribute('data-still-canvas', 'blocked'); } catch (e) {}
+      return true;
+    }
+    return false;
+  }
+
+  // getContext is the universal entry-point — every canvas that draws goes
+  // through it. Instrumenting here means we mark "probing" the instant a
+  // page touches a canvas, before the first draw call lands.
+  const origGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function () {
+    instrumentCanvas(this);
+    return origGetContext.apply(this, arguments);
+  };
+
+  function patchDrawMethods(proto, methods) {
+    if (!proto) return;
+    methods.forEach((m) => {
+      const orig = proto[m];
+      if (typeof orig !== 'function') return;
+      proto[m] = function () {
+        const skip = recordDraw(this && this.canvas);
+        if (skip) return; // blocked: no-op (saves CPU on the rAF loop)
+        return orig.apply(this, arguments);
+      };
+    });
+  }
+
+  if (typeof CanvasRenderingContext2D !== 'undefined') {
+    patchDrawMethods(CanvasRenderingContext2D.prototype, [
+      'clearRect', 'fillRect', 'strokeRect',
+      'drawImage', 'fill', 'stroke',
+      'fillText', 'strokeText', 'putImageData',
+    ]);
+  }
+  if (typeof WebGLRenderingContext !== 'undefined') {
+    patchDrawMethods(WebGLRenderingContext.prototype, ['drawArrays', 'drawElements']);
+  }
+  if (typeof WebGL2RenderingContext !== 'undefined') {
+    patchDrawMethods(WebGL2RenderingContext.prototype, [
+      'drawArrays', 'drawElements',
+      'drawArraysInstanced', 'drawElementsInstanced',
+    ]);
+  }
 })();


### PR DESCRIPTION
## Summary

Two complementary fixes for the homedepot.com Memorial Day hero animation, plus leftover v1.4 release polish bundled in.

### 1. Spacer-attr fix (commit `ac6b57e`)

- **Bug**: homedepot.com's Memorial Day hero (`14MAY26-HP-Bento1-MemorialDay-DSK-02.gif`, 1814×504, 852 KB) animates on screen with Still enabled.
- **Cause**: the `<img>` has `width="1" height="1"` HTML attrs (a layout placeholder — CSS utility classes `sui-w-full sui-h-full` resize it to fill its container). `isSpacer()` trusted those attrs alone, so at `document_start` — before load, when `naturalWidth` is still 0 — the GIF was marked `dataStill="static"` and unhidden. It then played.
- **Fix**: require natural-dim corroboration before treating 1×1 HTML attrs (or zero-layout offsetWidth/Height) as spacer evidence. Only trust the spacer signal when natural dims also confirm tiny (`nw,nh <= 4`).

### 2. Canvas animation detector (commit `56cf3b9`)

- **Why**: decorative canvas animations (confetti, particle backgrounds, WebGL hero scenes) bypass every existing strategy — no URL extension, no `<img>`/`<video>`, no `getAnimations()` hook. The defining invariant: they keep drawing.
- **How**: `main-world-patch.js` wraps `HTMLCanvasElement.prototype.getContext` and the draw methods on `CanvasRenderingContext2D`/`WebGLRenderingContext`/`WebGL2RenderingContext`. content.js carries a CSS rule that hides every canvas by default (`visibility:hidden`). Each canvas is classified within ~200 ms:
  - `probing` — still measuring, stay hidden
  - `blocked` — ≥3 frames drawn in the probe window → `display:none` + draw no-ops (saves rAF loop CPU too)
  - `static` — ≤2 frames → revealed
- **Migraine safety**: never paint a single visible animated frame. A pixel-sampler test asserts no rAF tick ever observes the canvas as `visibility:visible` AND `display:!=none` before block.

### 3. v1.4 release polish (commit `56cf3b9`)

- `release-notes-v1.4.md` — v1.4 release notes
- `app-store/description.md` — line covering Google Shopping AR previews (already-shipped PR #14 work)
- `tests/motion/fixture/ar-shopping-race.html` — fixture for the PR #14 race test
- `.gitignore` — drops the browser-generated `web-extension/_metadata/` indexed rulesets

## Verification

Spacer fix — recorded on virtual display via `MODE=compare ./tests/motion/run.sh https://www.homedepot.com/ 25`:

| variant | meanMotion | maxMotion | movingFrames% |
|---------|-----------:|----------:|--------------:|
| main    | 0.0983 | 5.5191 | 1.7 |
| current | 0.0214 | 1.0000 | 0.0 |

`main` heatmap shows motion across the entire viewport; `current` heatmap is fully black.

Canvas detector — two new Playwright tests in `tests/freeze.spec.js`:
1. End-state: animated canvas → `data-still-canvas="blocked"` + `display:none`; static canvas → revealed.
2. Pixel sampler: no rAF tick during the probe window observes the canvas as both `visibility:visible` and `display:!=none`.

## Test plan

- [x] `npx playwright test` — full suite passes including the 2 new canvas tests
- [x] Motion harness comparison on homedepot.com (numbers above)
- [x] Diagnose tool confirms Memorial Day hero now has `dataStill="replaced"` and src is the placeholder SVG
- [ ] Smoke-test on Safari (iOS/macOS) builds — content.js + main-world-patch.js mirrored to `Still/Still/Still Extension/Resources/`
- [ ] Spot-check newyorker.com on iOS — user reported a white-screen regression that may or may not be Still-related (not investigated yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)